### PR TITLE
Fixing an issue with retrieving calendar events logic. Adding eventId as an optional parameter in the Event object constructor.

### DIFF
--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -96,7 +96,7 @@ class DeviceCalendarPlugin {
           "[${ErrorCodes.invalidArguments}] ${ErrorMessages.invalidRetrieveEventsParams}");
     }
 
-    if (res.isSuccess) {
+    if (res.errorMessages.length == 0) {
       try {
         var eventsJson =
             await channel.invokeMethod('retrieveEvents', <String, Object>{

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -96,7 +96,7 @@ class DeviceCalendarPlugin {
           "[${ErrorCodes.invalidArguments}] ${ErrorMessages.invalidRetrieveEventsParams}");
     }
 
-    if (res.errorMessages.length == 0) {
+    if (res.errorMessages.isEmpty) {
       try {
         var eventsJson =
             await channel.invokeMethod('retrieveEvents', <String, Object>{

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -20,7 +20,7 @@ class DeviceCalendarPlugin {
   /// Returns a [Result] indicating if calendar READ and WRITE permissions
   /// have (true) or have not (false) been granted
   Future<Result<bool>> requestPermissions() async {
-    final res = new Result();
+    final res = new Result<bool>();
 
     try {
       res.data = await channel.invokeMethod('requestPermissions');

--- a/device_calendar/lib/src/models/event.dart
+++ b/device_calendar/lib/src/models/event.dart
@@ -29,7 +29,7 @@ class Event {
   /// A list of attendees for this event
   List<Attendee> attendees;
 
-  Event(this.calendarId, {this.title, this.start, this.end});
+  Event(this.calendarId, {this.eventId, this.title, this.start, this.end});
 
   Event.fromJson(Map<String, dynamic> json) {
     if (json == null) {


### PR DESCRIPTION
This should go in, before we release the plugin, as it' has a critical fix for retrieving calendar events