### PR TITLE
Fix issue with calendar stealing permission notifications

### DIFF
--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -81,7 +81,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
             // However, we can potentially run into this situation if plugin user is requesting other permissions (e.g. image picking) in his app
             //
             // There's nothing that can be done at this stage, besides finishing gracefully
-            return true
+            return false
         }
 
         val cachedValues: CalendarMethodsParametersCacheModel? = _cachedParametersMap[requestCode]

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -346,7 +346,6 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
             } catch (e: Exception) {
                 finishWithError(GENERIC_ERROR, e.message, pendingChannelResult)
                 println(e.message)
-            } finally {
             }
         } else {
             val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, CREATE_OR_UPDATE_EVENT_METHOD_CODE, calendarId)
@@ -509,8 +508,6 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
             cursor = contentResolver?.query(ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventId), eventProjection, null, null, null)
             if (cursor != null && cursor.moveToFirst()) {
                 isRecurring = !(cursor.getString(0)?.isNullOrEmpty() ?: true)
-            } else {
-
             }
         } catch (e: Exception) {
             println(e)


### PR DESCRIPTION
This is the fix I made to address the issue with the plugin "stealing" the permission from other plugins. Note that I didn't spend a lot of time looking at the code--I just know that it should be returning false when it isn't handling the permission.