### PR TITLE
accept nullable activity that can happen during headless execution @MaikuB 

### DIFF
--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.1 30th July 2019
+* [Android] Fixes issue [101](https://github.com/builttoroam/flutter_plugins/issues/101) where plugin results in a crash with headless execution
+
 # 0.2.0 30th July 2019
 * Add initial support for recurring events. Note that currently editing or deleting a recurring event will affect all instances of it. Future releases will look at supporting more advanced recurrence rules
 * **BREAKING CHANGE** [Android] Updated to use Gradle plugin to 3.4.2, Gradle wrapper to 5.1.1, Kotlin version to 1.3.41 and bumped Android dependencies

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -70,7 +70,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
     private var _context: Context? = null
     private var _gson: Gson? = null
 
-    constructor(activity: Activity, context: Context) {
+    constructor(activity: Activity?, context: Context) {
         _activity = activity
         _context = context
         var gsonBuilder = GsonBuilder()

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -55,7 +55,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
         @JvmStatic
         fun registerWith(registrar: Registrar): Unit {
             val context: Context = registrar.context()
-            val activity: Activity = registrar.activity()
+            val activity: Activity? = registrar.activity()
 
             val calendarDelegate = CalendarDelegate(activity, context)
             val instance = DeviceCalendarPlugin(registrar, calendarDelegate)

--- a/device_calendar/pubspec.yaml
+++ b/device_calendar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar
 description: A cross platform plugin for modifying calendars on the user's device.
-version: 0.2.0
+version: 0.2.1
 author: Built to Roam <info@builttoroam.com>
 homepage: https://github.com/builttoroam/flutter_plugins/tree/develop/device_calendar
 


### PR DESCRIPTION
@MaikuB fixed an issue where the plugin causes the app to crash when trying to execute background updates using the background fetch plugin. Issue: #101 