### PR TITLE
Support for advanced recurrence rules, attendees, reminders and fixes

### DIFF
--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 1.0.0 TBD
 * Support for more advanced recurrence rules
-* **BREAKING CHANGE** `retrieveCalendars` and `retrieveEvents` now return lists that cannot be modified
+* Update README to include information about using ProGuard for issue [99](https://github.com/builttoroam/flutter_plugins/issues/99)
+* Made event title optional to fix issue [72](https://github.com/builttoroam/flutter_plugins/issues/72)
+* Return information about the organiser of the event as per issue [73](https://github.com/builttoroam/flutter_plugins/issues/73)
+* **BREAKING CHANGE** `retrieveCalendars` and `retrieveEvents` now return lists that cannot be modified as part of address issue [113](https://github.com/builttoroam/flutter_plugins/issues/113)
 
 # 0.2.2 19th August 2019
 * Add support for specifying the location of an event. Thanks to [oli06](https://github.com/oli06) and [zemanux](https://github.com/zemanux) for submitting PRs to add the functionality to iOS and Android respectively

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Update README to include information about using ProGuard for issue [99](https://github.com/builttoroam/flutter_plugins/issues/99)
 * Made event title optional to fix issue [72](https://github.com/builttoroam/flutter_plugins/issues/72)
 * Return information about the organiser of the event as per issue [73](https://github.com/builttoroam/flutter_plugins/issues/73)
+* Return attendance status of attendees and if they're required for an event. These are details are different across iOS and Android and so are returned within platform-specific objects
 * **BREAKING CHANGE** `retrieveCalendars` and `retrieveEvents` now return lists that cannot be modified as part of address issue [113](https://github.com/builttoroam/flutter_plugins/issues/113)
 
 # 0.2.2 19th August 2019

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.0.0 TBD
 * Support for more advanced recurrence rules
+* **BREAKING CHANGE** `retrieveCalendars` and `retrieveEvents` now return lists that cannot be modified
 
 # 0.2.1+1 5th August 2019
 * Fixing date in changelog for version 0.2.1

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.0 TBD
+* Support for more advanced recurrence rules
+
 # 0.2.1+1 5th August 2019
 * Fixing date in changelog for version 0.2.1
 

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Made event title optional to fix issue [72](https://github.com/builttoroam/flutter_plugins/issues/72)
 * Return information about the organiser of the event as per issue [73](https://github.com/builttoroam/flutter_plugins/issues/73)
 * Return attendance status of attendees and if they're required for an event. These are details are different across iOS and Android and so are returned within platform-specific objects
+* Ability to modify attendees for an event
 * **BREAKING CHANGE** `retrieveCalendars` and `retrieveEvents` now return lists that cannot be modified as part of address issue [113](https://github.com/builttoroam/flutter_plugins/issues/113)
 
 # 0.2.2 19th August 2019

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.0 TBD
+# 1.0.0 28th August 2019
 * Support for more advanced recurrence rules
 * Update README to include information about using ProGuard for issue [99](https://github.com/builttoroam/flutter_plugins/issues/99)
 * Made event title optional to fix issue [72](https://github.com/builttoroam/flutter_plugins/issues/72)

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Return information about the organiser of the event as per issue [73](https://github.com/builttoroam/flutter_plugins/issues/73)
 * Return attendance status of attendees and if they're required for an event. These are details are different across iOS and Android and so are returned within platform-specific objects
 * Ability to modify attendees for an event
+* Ability to create reminders for events expressed in minutes before the event starts
 * **BREAKING CHANGE** `retrieveCalendars` and `retrieveEvents` now return lists that cannot be modified as part of address issue [113](https://github.com/builttoroam/flutter_plugins/issues/113)
 
 # 0.2.2 19th August 2019

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Return attendance status of attendees and if they're required for an event. These are details are different across iOS and Android and so are returned within platform-specific objects
 * Ability to modify attendees for an event
 * Ability to create reminders for events expressed in minutes before the event starts
-* **BREAKING CHANGE** `retrieveCalendars` and `retrieveEvents` now return lists that cannot be modified as part of address issue [113](https://github.com/builttoroam/flutter_plugins/issues/113)
+* **BREAKING CHANGE** `retrieveCalendars` and `retrieveEvents` now return lists that cannot be modified (`UnmodifiableListView`) to address part of  issue [113](https://github.com/builttoroam/flutter_plugins/issues/113)
 
 # 0.2.2 19th August 2019
 * Add support for specifying the location of an event. Thanks to [oli06](https://github.com/oli06) and [zemanux](https://github.com/zemanux) for submitting PRs to add the functionality to iOS and Android respectively

--- a/device_calendar/README.md
+++ b/device_calendar/README.md
@@ -23,6 +23,12 @@ The following will need to be added to the manifest file for your application to
 <uses-permission android:name="android.permission.WRITE_CALENDAR" />
 ```
 
+If you have Proguard enabled, you may need to add the following to your configuration (thanks to [Britannio Jarrett](https://github.com/britannio) who posted about it [here](https://github.com/builttoroam/flutter_plugins/issues/99))
+
+```
+-keep class com.builttoroam.devicecalendar.** { *; }
+```
+
 **IMPORTANT**: Since version 0.1.0, this version has migrated to use AndroidX instead of the deprecated Android support libraries. When using version 0.10.0 and onwards for this plugin, please ensure your application has been migrated following the guide [here](https://developer.android.com/jetpack/androidx/migrate)
 
 ## iOS Integration

--- a/device_calendar/README.md
+++ b/device_calendar/README.md
@@ -12,6 +12,7 @@ A cross platform plugin for modifying calendars on the user's device.
 * Ability to add, update or delete events from a calendar
 * Ability to set up recurring events (NOTE: deleting a recurring event will currently delete all instances of it)
 * Ability to modify attendees for an event (NOTE: certain information is read-only like attendance status. Please refer to API docs)
+* Ability to setup reminders for an event
 
 **NOTE**: there is a known issue where it looks as though specifying `weeksOfTheYear` and `setPositions` for recurrence rules doesn't appear to have an effect. Also note that the example app only provides entering simple scenarios e.g. it may be possible to specify multiple months that a yearly event should occur on but the example app will only allow specifying a single month.
 

--- a/device_calendar/README.md
+++ b/device_calendar/README.md
@@ -12,7 +12,7 @@ A cross platform plugin for modifying calendars on the user's device.
 * Ability to add, update or delete events from a calendar
 * Ability to set up recurring events (NOTE: deleting a recurring event will currently delete all instances of it)
 
-**NOTE**: there is a known issue where it looks as though specifying `weeksOfTheYear` and `setPositions` for recurrence rules doesn't appear to have an effect
+**NOTE**: there is a known issue where it looks as though specifying `weeksOfTheYear` and `setPositions` for recurrence rules doesn't appear to have an effect. Also note that the example app only provides entering simple scenarios e.g. it may be possible to specify multiple months that a yearly event should occur on but the example app will only allow specifying a single month.
 
 ## Android Integration
 

--- a/device_calendar/README.md
+++ b/device_calendar/README.md
@@ -12,6 +12,8 @@ A cross platform plugin for modifying calendars on the user's device.
 * Ability to add, update or delete events from a calendar
 * Ability to set up recurring events (NOTE: deleting a recurring event will currently delete all instances of it)
 
+**NOTE**: there is a known issue where it looks as though specifying `weeksOfTheYear` and `setPositions` for recurrence rules doesn't appear to have an effect
+
 ## Android Integration
 
 The following will need to be added to the manifest file for your application to indicate permissions to modify calendars a needed

--- a/device_calendar/README.md
+++ b/device_calendar/README.md
@@ -11,6 +11,7 @@ A cross platform plugin for modifying calendars on the user's device.
 * Retrieve events associated with a calendar
 * Ability to add, update or delete events from a calendar
 * Ability to set up recurring events (NOTE: deleting a recurring event will currently delete all instances of it)
+* Ability to modify attendees for an event (NOTE: certain information is read-only like attendance status. Please refer to API docs)
 
 **NOTE**: there is a known issue where it looks as though specifying `weeksOfTheYear` and `setPositions` for recurrence rules doesn't appear to have an effect. Also note that the example app only provides entering simple scenarios e.g. it may be possible to specify multiple months that a yearly event should occur on but the example app will only allow specifying a single month.
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -345,6 +345,12 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 return
             }
 
+            val calendar = retrieveCalendar(calendarId, pendingChannelResult, true)
+            if (calendar == null) {
+                finishWithError(NOT_FOUND, "Couldn't retrieve the Calendar with ID $calendarId", pendingChannelResult)
+                return
+            }
+
             val contentResolver: ContentResolver? = _context?.getContentResolver()
             val values = ContentValues()
             val duration: String? = null
@@ -357,8 +363,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
             values.put(Events.DURATION, duration)
 
             // MK using current device time zone
-            val calendar: java.util.Calendar = java.util.Calendar.getInstance()
-            val currentTimeZone: TimeZone = calendar.timeZone
+            val currentTimeZone: TimeZone = java.util.Calendar.getInstance().timeZone
             values.put(Events.EVENT_TIMEZONE, currentTimeZone.displayName)
             if (event.recurrenceRule != null) {
                 val recurrenceRuleParams = buildRecurrenceRuleParams(event.recurrenceRule!!)

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -97,91 +97,38 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 // indicate we're not handling the request
                 return false
 
-        when (cachedValues.calendarDelegateMethodCode) {
-            RETRIEVE_CALENDARS_REQUEST_CODE -> {
-                return handleRetrieveCalendarsRequest(permissionGranted, cachedValues, requestCode)
+        try {
+            if (!permissionGranted) {
+                finishWithError(NOT_AUTHORIZED, NOT_AUTHORIZED_MESSAGE, cachedValues.pendingChannelResult)
+                return false
             }
-            RETRIEVE_EVENTS_REQUEST_CODE -> {
-                return handleRetrieveEventsRequest(permissionGranted, cachedValues, requestCode)
+
+            when (cachedValues.calendarDelegateMethodCode) {
+                RETRIEVE_CALENDARS_REQUEST_CODE -> {
+                    retrieveCalendars(cachedValues.pendingChannelResult)
+                }
+                RETRIEVE_EVENTS_REQUEST_CODE -> {
+                    retrieveEvents(cachedValues.calendarId, cachedValues.calendarEventsStartDate, cachedValues.calendarEventsEndDate, cachedValues.calendarEventsIds, cachedValues.pendingChannelResult)
+                }
+                RETRIEVE_CALENDAR_REQUEST_CODE -> {
+                    retrieveCalendar(cachedValues.calendarId, cachedValues.pendingChannelResult)
+                }
+                CREATE_OR_UPDATE_EVENT_REQUEST_CODE -> {
+                    createOrUpdateEvent(cachedValues.calendarId, cachedValues.event, cachedValues.pendingChannelResult)
+                }
+                DELETE_EVENT_REQUEST_CODE -> {
+                    deleteEvent(cachedValues.eventId, cachedValues.calendarId, cachedValues.pendingChannelResult)
+                }
+                REQUEST_PERMISSIONS_REQUEST_CODE -> {
+                    finishWithSuccess(permissionGranted, cachedValues.pendingChannelResult)
+                }
             }
-            RETRIEVE_CALENDAR_REQUEST_CODE -> {
-                return handleRetrieveCalendarRequest(permissionGranted, cachedValues, requestCode)
-            }
-            CREATE_OR_UPDATE_EVENT_REQUEST_CODE -> {
-                return handleCreateOrUpdateEventRequest(permissionGranted, cachedValues, requestCode)
-            }
-            DELETE_EVENT_REQUEST_CODE -> {
-                return handleDeleteEventRequest(permissionGranted, cachedValues, requestCode)
-            }
-            REQUEST_PERMISSIONS_REQUEST_CODE -> {
-                return handlePermissionsRequest(permissionGranted, cachedValues)
-            }
+
+            return true
         }
-
-        return false
-    }
-
-    private fun handlePermissionsRequest(permissionGranted: Boolean, cachedValues: CalendarMethodsParametersCacheModel): Boolean {
-        finishWithSuccess(permissionGranted, cachedValues.pendingChannelResult)
-        return true
-    }
-
-    private fun handleDeleteEventRequest(permissionGranted: Boolean, cachedValues: CalendarMethodsParametersCacheModel, requestCode: Int): Boolean {
-        if (permissionGranted) {
-            deleteEvent(cachedValues.eventId, cachedValues.calendarId, cachedValues.pendingChannelResult)
-        } else {
-            finishWithError(NOT_AUTHORIZED, NOT_AUTHORIZED_MESSAGE, cachedValues.pendingChannelResult)
+        finally {
+            _cachedParametersMap.remove(cachedValues.calendarDelegateMethodCode)
         }
-
-        _cachedParametersMap.remove(requestCode)
-
-        return true
-    }
-
-    private fun handleCreateOrUpdateEventRequest(permissionGranted: Boolean, cachedValues: CalendarMethodsParametersCacheModel, requestCode: Int): Boolean {
-        if (permissionGranted) {
-            createOrUpdateEvent(cachedValues.calendarId, cachedValues.event, cachedValues.pendingChannelResult)
-        } else {
-            finishWithError(NOT_AUTHORIZED, NOT_AUTHORIZED_MESSAGE, cachedValues.pendingChannelResult)
-        }
-
-        _cachedParametersMap.remove(requestCode)
-
-        return true
-    }
-
-    private fun handleRetrieveCalendarRequest(permissionGranted: Boolean, cachedValues: CalendarMethodsParametersCacheModel, requestCode: Int): Boolean {
-        if (permissionGranted) {
-            retrieveCalendar(cachedValues.calendarId, cachedValues.pendingChannelResult)
-        } else {
-            finishWithError(NOT_AUTHORIZED, NOT_AUTHORIZED_MESSAGE, cachedValues.pendingChannelResult)
-        }
-
-        _cachedParametersMap.remove(requestCode)
-
-        return true
-    }
-
-    private fun handleRetrieveEventsRequest(permissionGranted: Boolean, cachedValues: CalendarMethodsParametersCacheModel, requestCode: Int): Boolean {
-        if (permissionGranted) {
-            retrieveEvents(cachedValues.calendarId, cachedValues.calendarEventsStartDate, cachedValues.calendarEventsEndDate, cachedValues.calendarEventsIds, cachedValues.pendingChannelResult)
-        } else {
-            finishWithError(NOT_AUTHORIZED, NOT_AUTHORIZED_MESSAGE, cachedValues.pendingChannelResult)
-        }
-
-        _cachedParametersMap.remove(requestCode)
-        return true
-    }
-
-    private fun handleRetrieveCalendarsRequest(permissionGranted: Boolean, cachedValues: CalendarMethodsParametersCacheModel, requestCode: Int): Boolean {
-        if (permissionGranted) {
-            retrieveCalendars(cachedValues.pendingChannelResult)
-        } else {
-            finishWithError(NOT_AUTHORIZED, NOT_AUTHORIZED_MESSAGE, cachedValues.pendingChannelResult)
-        }
-
-        _cachedParametersMap.remove(requestCode)
-        return true
     }
 
     fun requestPermissions(pendingChannelResult: MethodChannel.Result) {

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -530,7 +530,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
             return null
         }
 
-        return Attendee(cursor.getLong(ATTENDEE_EVENT_ID_INDEX), cursor.getString(ATTENDEE_EMAIL_INDEX), cursor.getString(ATTENDEE_NAME_INDEX), cursor.getInt(ATTENDEE_TYPE_INDEX) == CalendarContract.Attendees.TYPE_REQUIRED ,cursor.getInt(ATTENDEE_RELATIONSHIP_INDEX) == CalendarContract.Attendees.RELATIONSHIP_ORGANIZER)
+        return Attendee(cursor.getLong(ATTENDEE_EVENT_ID_INDEX), cursor.getString(ATTENDEE_EMAIL_INDEX), cursor.getString(ATTENDEE_NAME_INDEX), cursor.getInt(ATTENDEE_TYPE_INDEX) == CalendarContract.Attendees.TYPE_REQUIRED, cursor.getInt(ATTENDEE_RELATIONSHIP_INDEX) == CalendarContract.Attendees.RELATIONSHIP_ORGANIZER)
     }
 
     private fun isCalendarReadOnly(accessLevel: Int): Boolean {

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -581,8 +581,8 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                         val attendeeEvent = eventsMapById[attendee.eventId.toString()]
                         if (attendee.isOrganizer) {
                             attendeeEvent?.organizer = attendee
-                            continue
                         }
+
                         attendeeEvent?.attendees?.add(attendee)
                     }
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -504,7 +504,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         rfcRecurrenceRule.byDayPart?.forEach { weekdayNum ->
             val dayOfWeek = DayOfWeek.values().find { dayOfWeek ->  dayOfWeek.ordinal == weekdayNum.weekday.ordinal }
             if(dayOfWeek != null) {
-                recurrenceRule.daysOfWeek.add(dayOfWeek)
+                recurrenceRule.daysOfTheWeek.add(dayOfWeek)
             }
         }
         return recurrenceRule
@@ -622,9 +622,9 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
             rr.interval = recurrenceRule.interval!!
         }
 
-        if (recurrenceRule.daysOfWeek.isNotEmpty()) {
+        if (recurrenceRule.daysOfTheWeek.isNotEmpty()) {
             rr.byDayPart = mutableListOf()
-            for (dayOfWeek in recurrenceRule.daysOfWeek) {
+            for (dayOfWeek in recurrenceRule.daysOfTheWeek) {
                 val dayOfWeekCode = Weekday.values().find {
                     it.ordinal == dayOfWeek.ordinal
                 } ?: continue

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -17,6 +17,7 @@ import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_EVENT_
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_ID_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_NAME_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_PROJECTION
+import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_RELATIONSHIP_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_TYPE_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION
 import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION_ACCESS_LEVEL_INDEX
@@ -546,18 +547,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
             return null
         }
 
-        val id = cursor.getLong(ATTENDEE_ID_INDEX)
-        val eventId = cursor.getLong(ATTENDEE_EVENT_ID_INDEX)
-        val name = cursor.getString(ATTENDEE_NAME_INDEX)
-        val email = cursor.getString(ATTENDEE_EMAIL_INDEX)
-        val type = cursor.getInt(ATTENDEE_TYPE_INDEX)
-
-        val attendee = Attendee(name)
-        attendee.id = id
-        attendee.eventId = eventId
-        attendee.email = email
-        attendee.attendanceRequired = type == CalendarContract.Attendees.TYPE_REQUIRED
-
+        val attendee = Attendee(cursor.getLong(ATTENDEE_EVENT_ID_INDEX), cursor.getString(ATTENDEE_EMAIL_INDEX), cursor.getString(ATTENDEE_NAME_INDEX), cursor.getInt(ATTENDEE_RELATIONSHIP_INDEX) == CalendarContract.Attendees.RELATIONSHIP_ORGANIZER)
         return attendee
     }
 
@@ -589,6 +579,10 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
                     if (eventsMapById.containsKey(attendee.eventId.toString())) {
                         val attendeeEvent = eventsMapById[attendee.eventId.toString()]
+                        if (attendee.isOrganizer) {
+                            attendeeEvent?.organizer = attendee
+                            continue
+                        }
                         attendeeEvent?.attendees?.add(attendee)
                     }
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -385,7 +385,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
     fun deleteEvent(calendarId: String, eventId: String, pendingChannelResult: MethodChannel.Result) {
         if (arePermissionsGranted()) {
-            var existingCal = retrieveCalendar(calendarId, pendingChannelResult, true)
+            val existingCal = retrieveCalendar(calendarId, pendingChannelResult, true)
             if (existingCal == null) {
                 finishWithError(NOT_FOUND, "The calendar with the ID $calendarId could not be found", pendingChannelResult)
                 return
@@ -445,8 +445,6 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         val calId = cursor.getLong(CALENDAR_PROJECTION_ID_INDEX)
         val displayName = cursor.getString(CALENDAR_PROJECTION_DISPLAY_NAME_INDEX)
         val accessLevel = cursor.getInt(CALENDAR_PROJECTION_ACCESS_LEVEL_INDEX)
-        val accountName = cursor.getString(CALENDAR_PROJECTION_ACCOUNT_NAME_INDEX)
-        val ownerName = cursor.getString(CALENDAR_PROJECTION_OWNER_ACCOUNT_INDEX)
 
         val calendar = Calendar(calId.toString(), displayName)
         calendar.isReadOnly = isCalendarReadOnly(accessLevel)
@@ -468,7 +466,8 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         val allDay = cursor.getInt(EVENT_PROJECTION_ALL_DAY_INDEX) > 0
         val location = cursor.getString(EVENT_PROJECTION_EVENT_LOCATION_INDEX)
 
-        val event = Event(title)
+        val event = Event()
+        event.title = title
         event.eventId = eventId.toString()
         event.calendarId = calendarId
         event.description = description
@@ -484,15 +483,15 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         if(recurrenceRuleString == null) {
             return null
         }
-        var rfcRecurrenceRule = org.dmfs.rfc5545.recur.RecurrenceRule(recurrenceRuleString!!)
-        var frequency = when(rfcRecurrenceRule.freq) {
+        val rfcRecurrenceRule = org.dmfs.rfc5545.recur.RecurrenceRule(recurrenceRuleString!!)
+        val frequency = when(rfcRecurrenceRule.freq) {
             Freq.YEARLY -> RecurrenceFrequency.YEARLY
             Freq.MONTHLY -> RecurrenceFrequency.MONTHLY
             Freq.WEEKLY -> RecurrenceFrequency.WEEKLY
             Freq.DAILY -> RecurrenceFrequency.DAILY
             else -> null
         }
-        var recurrenceRule = RecurrenceRule(frequency!!)
+        val recurrenceRule = RecurrenceRule(frequency!!)
         if(rfcRecurrenceRule.count != null) {
             recurrenceRule.totalOccurrences = rfcRecurrenceRule.count
         }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -73,8 +73,9 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
     constructor(activity: Activity?, context: Context) {
         _activity = activity
         _context = context
-        var gsonBuilder = GsonBuilder()
+        val gsonBuilder = GsonBuilder()
         gsonBuilder.registerTypeAdapter(RecurrenceFrequency::class.java, RecurrenceFrequencySerializer())
+        gsonBuilder.registerTypeAdapter(DayOfWeek::class.java, DayOfWeekSerializer())
         _gson = gsonBuilder.create()
     }
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -55,21 +55,19 @@ import java.util.*
 
 
 class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
-
-    private val retrieveCalendarsMethodCode = 0
-    private val retrieveEventsMethodCode = retrieveCalendarsMethodCode + 1
-    private val retrieveCalendarMethodCode = retrieveEventsMethodCode + 1
-    private val createOrUpdateMethodCode = retrieveCalendarMethodCode + 1
-    private val deleteEventMethodCode = createOrUpdateMethodCode + 1
-    private val requestPermissionsMethodCode = deleteEventMethodCode + 1
-    private val partTemplate = ";%s="
-    private val byMonthDayPart = "BYMONTHDAY"
-    private val byMonthPart = "BYMONTH"
-    private val byWeekNoPart = "BYWEEKNO"
-    private val bySetPosPart = "BYSETPOS"
+    private val RETRIEVE_CALENDARS_REQUEST_CODE = 0
+    private val RETRIEVE_EVENTS_REQUEST_CODE = RETRIEVE_CALENDARS_REQUEST_CODE + 1
+    private val RETRIEVE_CALENDAR_REQUEST_CODE = RETRIEVE_EVENTS_REQUEST_CODE + 1
+    private val CREATE_OR_UPDATE_EVENT_REQUEST_CODE = RETRIEVE_CALENDAR_REQUEST_CODE + 1
+    private val DELETE_EVENT_REQUEST_CODE = CREATE_OR_UPDATE_EVENT_REQUEST_CODE + 1
+    private val REQUEST_PERMISSIONS_REQUEST_CODE = DELETE_EVENT_REQUEST_CODE + 1
+    private val PART_TEMPLATE = ";%s="
+    private val BYMONTHDAY_PART = "BYMONTHDAY"
+    private val BYMONTH_PART = "BYMONTH"
+    private val BYWEEKNO_PART = "BYWEEKNO"
+    private val BYSETPOS_PART = "BYSETPOS"
 
     private val _cachedParametersMap: MutableMap<Int, CalendarMethodsParametersCacheModel> = mutableMapOf()
-
     private var _activity: Activity? = null
     private var _context: Context? = null
     private var _gson: Gson? = null
@@ -97,22 +95,22 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 return false
 
         when (cachedValues.calendarDelegateMethodCode) {
-            retrieveCalendarsMethodCode -> {
+            RETRIEVE_CALENDARS_REQUEST_CODE -> {
                 return handleRetrieveCalendarsRequest(permissionGranted, cachedValues, requestCode)
             }
-            retrieveEventsMethodCode -> {
+            RETRIEVE_EVENTS_REQUEST_CODE -> {
                 return handleRetrieveEventsRequest(permissionGranted, cachedValues, requestCode)
             }
-            retrieveCalendarMethodCode -> {
+            RETRIEVE_CALENDAR_REQUEST_CODE -> {
                 return handleRetrieveCalendarRequest(permissionGranted, cachedValues, requestCode)
             }
-            createOrUpdateMethodCode -> {
+            CREATE_OR_UPDATE_EVENT_REQUEST_CODE -> {
                 return handleCreateOrUpdateEventRequest(permissionGranted, cachedValues, requestCode)
             }
-            deleteEventMethodCode -> {
+            DELETE_EVENT_REQUEST_CODE -> {
                 return handleDeleteEventRequest(permissionGranted, cachedValues, requestCode)
             }
-            requestPermissionsMethodCode -> {
+            REQUEST_PERMISSIONS_REQUEST_CODE -> {
                 return handlePermissionsRequest(permissionGranted, cachedValues)
             }
         }
@@ -187,7 +185,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         if (arePermissionsGranted()) {
             finishWithSuccess(true, pendingChannelResult)
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, requestPermissionsMethodCode)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, REQUEST_PERMISSIONS_REQUEST_CODE)
             requestPermissions(parameters)
         }
     }
@@ -217,7 +215,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 cursor?.close()
             }
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, retrieveCalendarsMethodCode)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, RETRIEVE_CALENDARS_REQUEST_CODE)
             requestPermissions(parameters)
         }
     }
@@ -255,7 +253,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 cursor?.close()
             }
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, retrieveCalendarMethodCode, calendarId)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, RETRIEVE_CALENDAR_REQUEST_CODE, calendarId)
             requestPermissions(parameters)
         }
 
@@ -315,7 +313,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
             finishWithSuccess(_gson?.toJson(events), pendingChannelResult)
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, retrieveEventsMethodCode, calendarId, startDate, endDate)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, RETRIEVE_EVENTS_REQUEST_CODE, calendarId, startDate, endDate)
             requestPermissions(parameters)
         }
 
@@ -370,7 +368,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 println(e.message)
             }
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, createOrUpdateMethodCode, calendarId)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, CREATE_OR_UPDATE_EVENT_REQUEST_CODE, calendarId)
             parameters.event = event
             requestPermissions(parameters)
         }
@@ -400,7 +398,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
             val deleteSucceeded = contentResolver?.delete(eventsUriWithId, null, null) ?: 0
             finishWithSuccess(deleteSucceeded > 0, pendingChannelResult)
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, deleteEventMethodCode, calendarId)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, DELETE_EVENT_REQUEST_CODE, calendarId)
             parameters.eventId = eventId
             requestPermissions(parameters)
         }
@@ -500,15 +498,15 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
         val rfcRecurrenceRuleString = rfcRecurrenceRule.toString()
         if (rfcRecurrenceRule.freq == Freq.MONTHLY) {
-            recurrenceRule.daysOfTheMonth = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, byMonthDayPart)
+            recurrenceRule.daysOfTheMonth = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, BYMONTHDAY_PART)
         }
 
         if (rfcRecurrenceRule.freq == Freq.YEARLY) {
-            recurrenceRule.monthsOfTheYear = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, byMonthPart)
-            recurrenceRule.weeksOfTheYear = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, byWeekNoPart)
+            recurrenceRule.monthsOfTheYear = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, BYMONTH_PART)
+            recurrenceRule.weeksOfTheYear = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, BYWEEKNO_PART)
         }
 
-        recurrenceRule.setPositions = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, bySetPosPart)
+        recurrenceRule.setPositions = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, BYSETPOS_PART)
         return recurrenceRule
     }
 
@@ -636,20 +634,20 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
         var rrString = rr.toString()
         if (recurrenceRule.recurrenceFrequency == RecurrenceFrequency.MONTHLY && recurrenceRule.daysOfTheMonth != null && recurrenceRule.daysOfTheMonth!!.isNotEmpty()) {
-            rrString = rrString.addPartWithValues(byMonthDayPart, recurrenceRule.daysOfTheMonth)
+            rrString = rrString.addPartWithValues(BYMONTHDAY_PART, recurrenceRule.daysOfTheMonth)
         }
 
         if (recurrenceRule.recurrenceFrequency == RecurrenceFrequency.YEARLY) {
             if (recurrenceRule.monthsOfTheYear != null && recurrenceRule.monthsOfTheYear!!.isNotEmpty()) {
-                rrString = rrString.addPartWithValues(byMonthPart, recurrenceRule.monthsOfTheYear)
+                rrString = rrString.addPartWithValues(BYMONTH_PART, recurrenceRule.monthsOfTheYear)
             }
 
             if (recurrenceRule.weeksOfTheYear != null && recurrenceRule.weeksOfTheYear!!.isNotEmpty()) {
-                rrString = rrString.addPartWithValues(byWeekNoPart, recurrenceRule.weeksOfTheYear)
+                rrString = rrString.addPartWithValues(BYWEEKNO_PART, recurrenceRule.weeksOfTheYear)
             }
         }
 
-        rrString = rrString.addPartWithValues(bySetPosPart, recurrenceRule.setPositions)
+        rrString = rrString.addPartWithValues(BYSETPOS_PART, recurrenceRule.setPositions)
         return rrString
     }
 
@@ -670,7 +668,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
     private fun String.addPartWithValues(partName: String, values: List<Int>?): String {
         if (values != null && values.isNotEmpty()) {
-            return this + partTemplate.format(partName) + values.joinToString(",")
+            return this + PART_TEMPLATE.format(partName) + values.joinToString(",")
         }
 
         return this

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -17,6 +17,7 @@ import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_EVENT_
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_NAME_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_PROJECTION
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_RELATIONSHIP_INDEX
+import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_STATUS_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_TYPE_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION
 import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION_ACCESS_LEVEL_INDEX
@@ -530,7 +531,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
             return null
         }
 
-        return Attendee(cursor.getLong(ATTENDEE_EVENT_ID_INDEX), cursor.getString(ATTENDEE_EMAIL_INDEX), cursor.getString(ATTENDEE_NAME_INDEX), cursor.getInt(ATTENDEE_TYPE_INDEX) == CalendarContract.Attendees.TYPE_REQUIRED, cursor.getInt(ATTENDEE_RELATIONSHIP_INDEX) == CalendarContract.Attendees.RELATIONSHIP_ORGANIZER)
+        return Attendee(cursor.getLong(ATTENDEE_EVENT_ID_INDEX), cursor.getString(ATTENDEE_EMAIL_INDEX), cursor.getString(ATTENDEE_NAME_INDEX), cursor.getInt(ATTENDEE_TYPE_INDEX) == CalendarContract.Attendees.TYPE_REQUIRED, cursor.getInt(ATTENDEE_STATUS_INDEX),cursor.getInt(ATTENDEE_RELATIONSHIP_INDEX) == CalendarContract.Attendees.RELATIONSHIP_ORGANIZER)
     }
 
     private fun isCalendarReadOnly(accessLevel: Int): Boolean {

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -13,7 +13,6 @@ import android.net.Uri
 import android.provider.CalendarContract
 import android.provider.CalendarContract.Events
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_EMAIL_INDEX
-import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_EVENT_ID_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_NAME_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_PROJECTION
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_RELATIONSHIP_INDEX
@@ -576,7 +575,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
             return null
         }
 
-        return Attendee(cursor.getLong(ATTENDEE_EVENT_ID_INDEX), cursor.getString(ATTENDEE_EMAIL_INDEX), cursor.getString(ATTENDEE_NAME_INDEX), cursor.getInt(ATTENDEE_TYPE_INDEX) == CalendarContract.Attendees.TYPE_REQUIRED, cursor.getInt(ATTENDEE_STATUS_INDEX),cursor.getInt(ATTENDEE_RELATIONSHIP_INDEX) == CalendarContract.Attendees.RELATIONSHIP_ORGANIZER)
+        return Attendee(cursor.getString(ATTENDEE_EMAIL_INDEX), cursor.getString(ATTENDEE_NAME_INDEX), cursor.getInt(ATTENDEE_TYPE_INDEX) == CalendarContract.Attendees.TYPE_REQUIRED, cursor.getInt(ATTENDEE_STATUS_INDEX),cursor.getInt(ATTENDEE_RELATIONSHIP_INDEX) == CalendarContract.Attendees.RELATIONSHIP_ORGANIZER)
     }
 
     private fun isCalendarReadOnly(accessLevel: Int): Boolean {

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -57,17 +57,17 @@ import java.util.*
 
 class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
-    private val RETRIEVE_CALENDARS_METHOD_CODE = 0
-    private val RETRIEVE_EVENTS_METHOD_CODE = RETRIEVE_CALENDARS_METHOD_CODE + 1
-    private val RETRIEVE_CALENDAR_METHOD_CODE = RETRIEVE_EVENTS_METHOD_CODE + 1
-    private val CREATE_OR_UPDATE_EVENT_METHOD_CODE = RETRIEVE_CALENDAR_METHOD_CODE + 1
-    private val DELETE_EVENT_METHOD_CODE = CREATE_OR_UPDATE_EVENT_METHOD_CODE + 1
-    private val REQUEST_PERMISSIONS_METHOD_CODE = DELETE_EVENT_METHOD_CODE + 1
-    private val PART_TEMPLATE = ";%s="
-    private val BYMONTHDAY_PART = "BYMONTHDAY"
-    private val BYMONTH_PART = "BYMONTH"
-    private val BYWEEKNO_PART = "BYWEEKNO"
-    private val BYSETPOS_PART = "BYSETPOS"
+    private val retrieveCalendarsMethodCode = 0
+    private val retrieveEventsMethodCode = retrieveCalendarsMethodCode + 1
+    private val retrieveCalendarMethodCode = retrieveEventsMethodCode + 1
+    private val createOrUpdateMethodCode = retrieveCalendarMethodCode + 1
+    private val deleteEventMethodCode = createOrUpdateMethodCode + 1
+    private val requestPermissionsMethodCode = deleteEventMethodCode + 1
+    private val partTemplate = ";%s="
+    private val byMonthDayPart = "BYMONTHDAY"
+    private val byMonthPart = "BYMONTH"
+    private val byWeekNoPart = "BYWEEKNO"
+    private val bySetPosPart = "BYSETPOS"
 
     private val _cachedParametersMap: MutableMap<Int, CalendarMethodsParametersCacheModel> = mutableMapOf()
 
@@ -100,22 +100,22 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         }
 
         when (cachedValues.calendarDelegateMethodCode) {
-            RETRIEVE_CALENDARS_METHOD_CODE -> {
+            retrieveCalendarsMethodCode -> {
                 return handleRetrieveCalendarsRequest(permissionGranted, cachedValues, requestCode)
             }
-            RETRIEVE_EVENTS_METHOD_CODE -> {
+            retrieveEventsMethodCode -> {
                 return handleRetrieveEventsRequest(permissionGranted, cachedValues, requestCode)
             }
-            RETRIEVE_CALENDAR_METHOD_CODE -> {
+            retrieveCalendarMethodCode -> {
                 return handleRetrieveCalendarRequest(permissionGranted, cachedValues, requestCode)
             }
-            CREATE_OR_UPDATE_EVENT_METHOD_CODE -> {
+            createOrUpdateMethodCode -> {
                 return handleCreateOrUpdateEventRequest(permissionGranted, cachedValues, requestCode)
             }
-            DELETE_EVENT_METHOD_CODE -> {
+            deleteEventMethodCode -> {
                 return handleDeleteEventRequest(permissionGranted, cachedValues, requestCode)
             }
-            REQUEST_PERMISSIONS_METHOD_CODE -> {
+            requestPermissionsMethodCode -> {
                 return handlePermissionsRequest(permissionGranted, cachedValues)
             }
         }
@@ -192,7 +192,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         if (arePermissionsGranted()) {
             finishWithSuccess(true, pendingChannelResult)
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, REQUEST_PERMISSIONS_METHOD_CODE)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, requestPermissionsMethodCode)
             requestPermissions(parameters)
         }
     }
@@ -228,7 +228,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 cursor?.close()
             }
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, RETRIEVE_CALENDARS_METHOD_CODE)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, retrieveCalendarsMethodCode)
             requestPermissions(parameters)
         }
     }
@@ -266,7 +266,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 cursor?.close()
             }
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, RETRIEVE_CALENDAR_METHOD_CODE, calendarId)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, retrieveCalendarMethodCode, calendarId)
             requestPermissions(parameters)
         }
 
@@ -330,7 +330,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
             finishWithSuccess(_gson?.toJson(events), pendingChannelResult)
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, RETRIEVE_EVENTS_METHOD_CODE, calendarId, startDate, endDate)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, retrieveEventsMethodCode, calendarId, startDate, endDate)
             requestPermissions(parameters)
         }
 
@@ -379,7 +379,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 println(e.message)
             }
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, CREATE_OR_UPDATE_EVENT_METHOD_CODE, calendarId)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, createOrUpdateMethodCode, calendarId)
             parameters.event = event
             requestPermissions(parameters)
         }
@@ -411,7 +411,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
             finishWithSuccess(deleteSucceeded > 0, pendingChannelResult)
         } else {
-            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, DELETE_EVENT_METHOD_CODE, calendarId)
+            val parameters = CalendarMethodsParametersCacheModel(pendingChannelResult, deleteEventMethodCode, calendarId)
             parameters.eventId = eventId
             requestPermissions(parameters)
         }
@@ -512,15 +512,15 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
         val rfcRecurrenceRuleString = rfcRecurrenceRule.toString()
         if (rfcRecurrenceRule.freq == Freq.MONTHLY) {
-            recurrenceRule.daysOfTheMonth = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, BYMONTHDAY_PART)
+            recurrenceRule.daysOfTheMonth = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, byMonthDayPart)
         }
 
         if (rfcRecurrenceRule.freq == Freq.YEARLY) {
-            recurrenceRule.monthsOfTheYear = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, BYMONTH_PART)
-            recurrenceRule.weeksOfTheYear = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, BYWEEKNO_PART)
+            recurrenceRule.monthsOfTheYear = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, byMonthPart)
+            recurrenceRule.weeksOfTheYear = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, byWeekNoPart)
         }
 
-        recurrenceRule.setPositions = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, BYSETPOS_PART)
+        recurrenceRule.setPositions = convertCalendarPartToNumericValues(rfcRecurrenceRuleString, bySetPosPart)
         return recurrenceRule
     }
 
@@ -676,27 +676,27 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
         var rrString = rr.toString()
         if (recurrenceRule.recurrenceFrequency == RecurrenceFrequency.MONTHLY && recurrenceRule.daysOfTheMonth != null && recurrenceRule.daysOfTheMonth!!.isNotEmpty()) {
-            rrString = rrString.addPartWithValues(BYMONTHDAY_PART, recurrenceRule.daysOfTheMonth)
+            rrString = rrString.addPartWithValues(byMonthDayPart, recurrenceRule.daysOfTheMonth)
         }
 
         if (recurrenceRule.recurrenceFrequency == RecurrenceFrequency.YEARLY) {
             if (recurrenceRule.monthsOfTheYear != null && recurrenceRule.monthsOfTheYear!!.isNotEmpty()) {
-                rrString = rrString.addPartWithValues(BYMONTH_PART, recurrenceRule.monthsOfTheYear)
+                rrString = rrString.addPartWithValues(byMonthPart, recurrenceRule.monthsOfTheYear)
             }
 
             if (recurrenceRule.weeksOfTheYear != null && recurrenceRule.weeksOfTheYear!!.isNotEmpty()) {
-                rrString = rrString.addPartWithValues(BYWEEKNO_PART, recurrenceRule.weeksOfTheYear)
+                rrString = rrString.addPartWithValues(byWeekNoPart, recurrenceRule.weeksOfTheYear)
             }
         }
 
-        rrString = rrString.addPartWithValues(BYSETPOS_PART, recurrenceRule.setPositions)
+        rrString = rrString.addPartWithValues(bySetPosPart, recurrenceRule.setPositions)
         return rrString
     }
 
 
     private fun String.addPartWithValues(partName: String, values: List<Int>?): String {
         if (values != null && values.isNotEmpty()) {
-            return this + PART_TEMPLATE.format(partName) + values.joinToString(",")
+            return this + partTemplate.format(partName) + values.joinToString(",")
         }
 
         return this

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DayOfWeekSerializer.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DayOfWeekSerializer.kt
@@ -9,6 +9,6 @@ class DayOfWeekSerializer: JsonSerializer<DayOfWeek> {
         if(src != null) {
             return JsonPrimitive(src.ordinal)
         }
-        return JsonObject()//To change body of created functions use File | Settings | File Templates.
+        return JsonObject()
     }
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DayOfWeekSerializer.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DayOfWeekSerializer.kt
@@ -1,0 +1,14 @@
+package com.builttoroam.devicecalendar
+
+import com.builttoroam.devicecalendar.common.DayOfWeek
+import com.google.gson.*
+import java.lang.reflect.Type
+
+class DayOfWeekSerializer: JsonSerializer<DayOfWeek> {
+    override fun serialize(src: DayOfWeek?, typeOfSrc: Type?, context: JsonSerializationContext?): JsonElement {
+        if(src != null) {
+            return JsonPrimitive(src.ordinal)
+        }
+        return JsonObject()//To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import com.builttoroam.devicecalendar.common.DayOfWeek
 import com.builttoroam.devicecalendar.common.RecurrenceFrequency
+import com.builttoroam.devicecalendar.models.Attendee
 import com.builttoroam.devicecalendar.models.Event
 import com.builttoroam.devicecalendar.models.RecurrenceRule
 
@@ -44,6 +45,10 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private val MONTHS_OF_THE_YEAR_ARGUMENT = "monthsOfTheYear"
     private val WEEKS_OF_THE_YEAR_ARGUMENT = "weeksOfTheYear"
     private val SET_POSITIONS_ARGUMENT = "setPositions"
+    private val ATTENDEES_ARGUMENT = "attendees"
+    private val EMAIL_ADDRESS_ARGUMENT = "emailAddress"
+    private val NAME_ARGUMENT = "name"
+    private val IS_REQUIRED_ARGUMENT = "isRequired"
 
     private lateinit var _registrar: Registrar
     private lateinit var _calendarDelegate: CalendarDelegate
@@ -122,6 +127,14 @@ class DeviceCalendarPlugin() : MethodCallHandler {
         if (call.hasArgument(RECURRENCE_RULE_ARGUMENT) && call.argument<Map<String, Any>>(RECURRENCE_RULE_ARGUMENT) != null) {
             val recurrenceRule = parseRecurrenceRuleArgs(call)
             event.recurrenceRule = recurrenceRule
+        }
+
+        if (call.hasArgument(ATTENDEES_ARGUMENT) && call.argument<List<Map<String, Any>>>(ATTENDEES_ARGUMENT) != null) {
+            event.attendees = mutableListOf()
+            val attendeesArgs = call.argument<List<Map<String, Any>>>(ATTENDEES_ARGUMENT)!!
+            for (attendeeArgs in attendeesArgs) {
+                event.attendees.add(Attendee(null, attendeeArgs[EMAIL_ADDRESS_ARGUMENT] as String, attendeeArgs[NAME_ARGUMENT] as String?, attendeeArgs[IS_REQUIRED_ARGUMENT] as Boolean?, null, null))
+            }
         }
 
         return event

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -45,7 +45,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private val TOTAL_OCCURRENCES_ARGUMENT = "totalOccurrences"
     private val INTERVAL_ARGUMENT = "interval"
     private val END_DATE_ARGUMENT = "endDate"
-    private val DAYS_OF_WEEK_ARGUMENT = "daysOfWeek"
+    private val DAYS_OF_THE_WEEK_ARGUMENT = "daysOfTheWeek"
 
 
     private constructor(registrar: Registrar, calendarDelegate: CalendarDelegate) : this() {
@@ -55,7 +55,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
 
     companion object {
         @JvmStatic
-        fun registerWith(registrar: Registrar): Unit {
+        fun registerWith(registrar: Registrar) {
             val context: Context = registrar.context()
             val activity: Activity? = registrar.activity()
 
@@ -123,10 +123,10 @@ class DeviceCalendarPlugin() : MethodCallHandler {
                         recurrenceRule.endDate = recurrenceRuleArgs[END_DATE_ARGUMENT] as Long
                     }
 
-                    if (recurrenceRuleArgs.containsKey(DAYS_OF_WEEK_ARGUMENT)) {
-                        val daysOfWeek = recurrenceRuleArgs[DAYS_OF_WEEK_ARGUMENT] as List<Int>
+                    if (recurrenceRuleArgs.containsKey(DAYS_OF_THE_WEEK_ARGUMENT)) {
+                        val daysOfWeek = recurrenceRuleArgs[DAYS_OF_THE_WEEK_ARGUMENT] as List<Int>
                         for (dayOfWeek in daysOfWeek) {
-                            recurrenceRule.daysOfWeek.add(DayOfWeek.values()[dayOfWeek])
+                            recurrenceRule.daysOfTheWeek.add(DayOfWeek.values()[dayOfWeek])
                         }
                     }
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -71,7 +71,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
             registrar.addRequestPermissionsResultListener(calendarDelegate)
         }
     }
-    
+
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             REQUEST_PERMISSIONS_METHOD -> {

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -13,44 +13,40 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-
 const val CHANNEL_NAME = "plugins.builttoroam.com/device_calendar"
 
-
 class DeviceCalendarPlugin() : MethodCallHandler {
+    // Methods
+    private val REQUEST_PERMISSIONS_METHOD = "requestPermissions"
+    private val HAS_PERMISSIONS_METHOD = "hasPermissions"
+    private val RETRIEVE_CALENDARS_METHOD = "retrieveCalendars"
+    private val RETRIEVE_EVENTS_METHOD = "retrieveEvents"
+    private val DELETE_EVENT_METHOD = "deleteEvent"
+    private val CREATE_OR_UPDATE_EVENT_METHOD = "createOrUpdateEvent"
+
+    // Method arguments
+    private val CALENDAR_ID_ARGUMENT = "calendarId"
+    private val START_DATE_ARGUMENT = "startDate"
+    private val END_DATE_ARGUMENT = "endDate"
+    private val EVENT_IDS_ARGUMENT = "eventIds"
+    private val EVENT_ID_ARGUMENT = "eventId"
+    private val EVENT_TITLE_ARGUMENT = "eventTitle"
+    private val EVENT_LOCATION_ARGUMENT = "eventLocation"
+    private val EVENT_DESCRIPTION_ARGUMENT = "eventDescription"
+    private val EVENT_START_DATE_ARGUMENT = "eventStartDate"
+    private val EVENT_END_DATE_ARGUMENT = "eventEndDate"
+    private val RECURRENCE_RULE_ARGUMENT = "recurrenceRule"
+    private val RECURRENCE_FREQUENCY_ARGUMENT = "recurrenceFrequency"
+    private val TOTAL_OCCURRENCES_ARGUMENT = "totalOccurrences"
+    private val INTERVAL_ARGUMENT = "interval"
+    private val DAYS_OF_THE_WEEK_ARGUMENT = "daysOfTheWeek"
+    private val DAYS_OF_THE_MONTH_ARGUMENT = "daysOfTheMonth"
+    private val MONTHS_OF_THE_YEAR_ARGUMENT = "monthsOfTheYear"
+    private val WEEKS_OF_THE_YEAR_ARGUMENT = "weeksOfTheYear"
+    private val SET_POSITIONS_ARGUMENT = "setPositions"
 
     private lateinit var _registrar: Registrar
     private lateinit var _calendarDelegate: CalendarDelegate
-
-    // Methods
-    private val requestPermissionsMethod = "requestPermissions"
-    private val hasPermissionsMethod = "hasPermissions"
-    private val retrieveCalendarsMethod = "retrieveCalendars"
-    private val retrieveEventsMethod = "retrieveEvents"
-    private val deleteEventMethod = "deleteEvent"
-    private val createOrUpdateEventMethod = "createOrUpdateEvent"
-
-    // Method arguments
-    private val calendarIdArgument = "calendarId"
-    private val calendarEventsStartDateArgument = "startDate"
-    private val calendarEventsEndDateArgument = "endDate"
-    private val calendarEventIdsArgument = "eventIds"
-    private val eventIdArgument = "eventId"
-    private val eventTitleArgument = "eventTitle"
-    private val eventLocationArgument = "eventLocation"
-    private val eventDescriptionArgument = "eventDescription"
-    private val eventStartDateArgument = "eventStartDate"
-    private val eventEndDateArgument = "eventEndDate"
-    private val recurrenceRuleArgument = "recurrenceRule"
-    private val recurrenceFrequencyArgument = "recurrenceFrequency"
-    private val totalOccurrencesArgument = "totalOccurrences"
-    private val intervalArgument = "interval"
-    private val endDateArgument = "endDate"
-    private val daysOfTheWeekArgument = "daysOfTheWeek"
-    private val daysOfTheMonthArgument = "daysOfTheMonth"
-    private val monthsOfTheYearArgument = "monthsOfTheYear"
-    private val weeksOfTheYearArgument = "weeksOfTheYear"
-    private val setPositionsArgument = "setPositions"
 
     private constructor(registrar: Registrar, calendarDelegate: CalendarDelegate) : this() {
         _registrar = registrar
@@ -78,32 +74,32 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
-            requestPermissionsMethod -> {
+            REQUEST_PERMISSIONS_METHOD -> {
                 _calendarDelegate.requestPermissions(result)
             }
-            hasPermissionsMethod -> {
+            HAS_PERMISSIONS_METHOD -> {
                 _calendarDelegate.hasPermissions(result)
             }
-            retrieveCalendarsMethod -> {
+            RETRIEVE_CALENDARS_METHOD -> {
                 _calendarDelegate.retrieveCalendars(result)
             }
-            retrieveEventsMethod -> {
-                val calendarId = call.argument<String>(calendarIdArgument)
-                val startDate = call.argument<Long>(calendarEventsStartDateArgument)
-                val endDate = call.argument<Long>(calendarEventsEndDateArgument)
-                val eventIds = call.argument<List<String>>(calendarEventIdsArgument) ?: listOf()
+            RETRIEVE_EVENTS_METHOD -> {
+                val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
+                val startDate = call.argument<Long>(START_DATE_ARGUMENT)
+                val endDate = call.argument<Long>(END_DATE_ARGUMENT)
+                val eventIds = call.argument<List<String>>(EVENT_IDS_ARGUMENT) ?: listOf()
 
                 _calendarDelegate.retrieveEvents(calendarId!!, startDate, endDate, eventIds, result)
             }
-            createOrUpdateEventMethod -> {
-                val calendarId = call.argument<String>(calendarIdArgument)
+            CREATE_OR_UPDATE_EVENT_METHOD -> {
+                val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
                 val event = parseEventArgs(call, calendarId)
 
                 _calendarDelegate.createOrUpdateEvent(calendarId!!, event, result)
             }
-            deleteEventMethod -> {
-                val calendarId = call.argument<String>(calendarIdArgument)
-                val eventId = call.argument<String>(eventIdArgument)
+            DELETE_EVENT_METHOD -> {
+                val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
+                val eventId = call.argument<String>(EVENT_ID_ARGUMENT)
 
                 _calendarDelegate.deleteEvent(calendarId!!, eventId!!, result)
             }
@@ -115,15 +111,15 @@ class DeviceCalendarPlugin() : MethodCallHandler {
 
     private fun parseEventArgs(call: MethodCall, calendarId: String?): Event {
         val event = Event()
-        event.title = call.argument<String>(eventTitleArgument)
+        event.title = call.argument<String>(EVENT_TITLE_ARGUMENT)
         event.calendarId = calendarId
-        event.eventId = call.argument<String>(eventIdArgument)
-        event.description = call.argument<String>(eventDescriptionArgument)
-        event.start = call.argument<Long>(eventStartDateArgument)!!
-        event.end = call.argument<Long>(eventEndDateArgument)!!
-        event.location = call.argument<String>(eventLocationArgument)
+        event.eventId = call.argument<String>(EVENT_ID_ARGUMENT)
+        event.description = call.argument<String>(EVENT_DESCRIPTION_ARGUMENT)
+        event.start = call.argument<Long>(EVENT_START_DATE_ARGUMENT)!!
+        event.end = call.argument<Long>(EVENT_END_DATE_ARGUMENT)!!
+        event.location = call.argument<String>(EVENT_LOCATION_ARGUMENT)
 
-        if (call.hasArgument(recurrenceRuleArgument) && call.argument<Map<String, Any>>(recurrenceRuleArgument) != null) {
+        if (call.hasArgument(RECURRENCE_RULE_ARGUMENT) && call.argument<Map<String, Any>>(RECURRENCE_RULE_ARGUMENT) != null) {
             val recurrenceRule = parseRecurrenceRuleArgs(call)
             event.recurrenceRule = recurrenceRule
         }
@@ -132,39 +128,39 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     }
 
     private fun parseRecurrenceRuleArgs(call: MethodCall): RecurrenceRule {
-        val recurrenceRuleArgs = call.argument<Map<String, Any>>(recurrenceRuleArgument)!!
-        val recurrenceFrequencyIndex = recurrenceRuleArgs[recurrenceFrequencyArgument] as Int
+        val recurrenceRuleArgs = call.argument<Map<String, Any>>(RECURRENCE_RULE_ARGUMENT)!!
+        val recurrenceFrequencyIndex = recurrenceRuleArgs[RECURRENCE_FREQUENCY_ARGUMENT] as Int
         val recurrenceRule = RecurrenceRule(RecurrenceFrequency.values()[recurrenceFrequencyIndex])
-        if (recurrenceRuleArgs.containsKey(totalOccurrencesArgument)) {
-            recurrenceRule.totalOccurrences = recurrenceRuleArgs[totalOccurrencesArgument] as Int
+        if (recurrenceRuleArgs.containsKey(TOTAL_OCCURRENCES_ARGUMENT)) {
+            recurrenceRule.totalOccurrences = recurrenceRuleArgs[TOTAL_OCCURRENCES_ARGUMENT] as Int
         }
 
-        if (recurrenceRuleArgs.containsKey(intervalArgument)) {
-            recurrenceRule.interval = recurrenceRuleArgs[intervalArgument] as Int
+        if (recurrenceRuleArgs.containsKey(INTERVAL_ARGUMENT)) {
+            recurrenceRule.interval = recurrenceRuleArgs[INTERVAL_ARGUMENT] as Int
         }
 
-        if (recurrenceRuleArgs.containsKey(endDateArgument)) {
-            recurrenceRule.endDate = recurrenceRuleArgs[endDateArgument] as Long
+        if (recurrenceRuleArgs.containsKey(END_DATE_ARGUMENT)) {
+            recurrenceRule.endDate = recurrenceRuleArgs[END_DATE_ARGUMENT] as Long
         }
 
-        if (recurrenceRuleArgs.containsKey(daysOfTheWeekArgument)) {
-            recurrenceRule.daysOfTheWeek = recurrenceRuleArgs[daysOfTheWeekArgument].toListOf<Int>()?.map { DayOfWeek.values()[it] }?.toMutableList()
+        if (recurrenceRuleArgs.containsKey(DAYS_OF_THE_WEEK_ARGUMENT)) {
+            recurrenceRule.daysOfTheWeek = recurrenceRuleArgs[DAYS_OF_THE_WEEK_ARGUMENT].toListOf<Int>()?.map { DayOfWeek.values()[it] }?.toMutableList()
         }
 
-        if (recurrenceRuleArgs.containsKey(daysOfTheMonthArgument)) {
-            recurrenceRule.daysOfTheMonth = recurrenceRuleArgs[daysOfTheMonthArgument].toMutableListOf()
+        if (recurrenceRuleArgs.containsKey(DAYS_OF_THE_MONTH_ARGUMENT)) {
+            recurrenceRule.daysOfTheMonth = recurrenceRuleArgs[DAYS_OF_THE_MONTH_ARGUMENT].toMutableListOf()
         }
 
-        if (recurrenceRuleArgs.containsKey(monthsOfTheYearArgument)) {
-            recurrenceRule.monthsOfTheYear = recurrenceRuleArgs[monthsOfTheYearArgument].toMutableListOf()
+        if (recurrenceRuleArgs.containsKey(MONTHS_OF_THE_YEAR_ARGUMENT)) {
+            recurrenceRule.monthsOfTheYear = recurrenceRuleArgs[MONTHS_OF_THE_YEAR_ARGUMENT].toMutableListOf()
         }
 
-        if (recurrenceRuleArgs.containsKey(weeksOfTheYearArgument)) {
-            recurrenceRule.weeksOfTheYear = recurrenceRuleArgs[weeksOfTheYearArgument].toMutableListOf()
+        if (recurrenceRuleArgs.containsKey(WEEKS_OF_THE_YEAR_ARGUMENT)) {
+            recurrenceRule.weeksOfTheYear = recurrenceRuleArgs[WEEKS_OF_THE_YEAR_ARGUMENT].toMutableListOf()
         }
 
-        if (recurrenceRuleArgs.containsKey(setPositionsArgument)) {
-            recurrenceRule.setPositions = recurrenceRuleArgs[setPositionsArgument].toMutableListOf()
+        if (recurrenceRuleArgs.containsKey(SET_POSITIONS_ARGUMENT)) {
+            recurrenceRule.setPositions = recurrenceRuleArgs[SET_POSITIONS_ARGUMENT].toMutableListOf()
         }
 
         return recurrenceRule

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -48,6 +48,8 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private val DAYS_OF_THE_WEEK_ARGUMENT = "daysOfTheWeek"
     private val DAYS_OF_THE_MONTH_ARGUMENT = "daysOfTheMonth"
     private val MONTHS_OF_THE_YEAR_ARGUMENT = "monthsOfTheYear"
+    private val WEEKS_OF_THE_YEAR_ARGUMENT = "weeksOfTheYear"
+    private val SET_POSITIONS_ARGUMENT = "setPositions"
 
 
     private constructor(registrar: Registrar, calendarDelegate: CalendarDelegate) : this() {
@@ -129,9 +131,9 @@ class DeviceCalendarPlugin() : MethodCallHandler {
 
         if (call.hasArgument(RECURRENCE_RULE_ARGUMENT) && call.argument<Map<String, Any>>(RECURRENCE_RULE_ARGUMENT) != null) {
             val recurrenceRule = parseRecurrenceRuleArgs(call)
-
             event.recurrenceRule = recurrenceRule
         }
+
         return event
     }
 
@@ -162,6 +164,15 @@ class DeviceCalendarPlugin() : MethodCallHandler {
         if (recurrenceRuleArgs.containsKey(MONTHS_OF_THE_YEAR_ARGUMENT)) {
             recurrenceRule.monthsOfTheYear = recurrenceRuleArgs[MONTHS_OF_THE_YEAR_ARGUMENT].toMutableListOf()
         }
+
+        if(recurrenceRuleArgs.containsKey(WEEKS_OF_THE_YEAR_ARGUMENT)) {
+            recurrenceRule.weeksOfTheYear = recurrenceRuleArgs[WEEKS_OF_THE_YEAR_ARGUMENT].toMutableListOf()
+        }
+
+        if(recurrenceRuleArgs.containsKey(SET_POSITIONS_ARGUMENT)) {
+            recurrenceRule.setPositions = recurrenceRuleArgs[SET_POSITIONS_ARGUMENT].toMutableListOf()
+        }
+
         return recurrenceRule
     }
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -97,7 +97,8 @@ class DeviceCalendarPlugin() : MethodCallHandler {
                 val eventStart = call.argument<Long>(EVENT_START_DATE_ARGUMENT)
                 val eventEnd = call.argument<Long>(EVENT_END_DATE_ARGUMENT)
 
-                val event = Event(eventTitle!!)
+                val event = Event()
+                event.title = eventTitle
                 event.calendarId = calendarId
                 event.eventId = eventId
                 event.description = eventDescription

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -23,33 +23,33 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private lateinit var _calendarDelegate: CalendarDelegate
 
     // Methods
-    private val REQUEST_PERMISSIONS_METHOD = "requestPermissions"
-    private val HAS_PERMISSIONS_METHOD = "hasPermissions"
-    private val RETRIEVE_CALENDARS_METHOD = "retrieveCalendars"
-    private val RETRIEVE_EVENTS_METHOD = "retrieveEvents"
-    private val DELETE_EVENT_METHOD = "deleteEvent"
-    private val CREATE_OR_UPDATE_EVENT_METHOD = "createOrUpdateEvent"
+    private val requestPermissionsMethod = "requestPermissions"
+    private val hasPermissionsMethod = "hasPermissions"
+    private val retrieveCalendarsMethod = "retrieveCalendars"
+    private val retrieveEventsMethod = "retrieveEvents"
+    private val deleteEventMethod = "deleteEvent"
+    private val createOrUpdateEventMethod = "createOrUpdateEvent"
 
     // Method arguments
-    private val CALENDAR_ID_ARGUMENT = "calendarId"
-    private val CALENDAR_EVENTS_START_DATE_ARGUMENT = "startDate"
-    private val CALENDAR_EVENTS_END_DATE_ARGUMENT = "endDate"
-    private val CALENDAR_EVENTS_IDS_ARGUMENT = "eventIds"
-    private val EVENT_ID_ARGUMENT = "eventId"
-    private val EVENT_TITLE_ARGUMENT = "eventTitle"
-    private val EVENT_DESCRIPTION_ARGUMENT = "eventDescription"
-    private val EVENT_START_DATE_ARGUMENT = "eventStartDate"
-    private val EVENT_END_DATE_ARGUMENT = "eventEndDate"
-    private val RECURRENCE_RULE_ARGUMENT = "recurrenceRule"
-    private val RECURRENCE_FREQUENCY_ARGUMENT = "recurrenceFrequency"
-    private val TOTAL_OCCURRENCES_ARGUMENT = "totalOccurrences"
-    private val INTERVAL_ARGUMENT = "interval"
-    private val END_DATE_ARGUMENT = "endDate"
-    private val DAYS_OF_THE_WEEK_ARGUMENT = "daysOfTheWeek"
-    private val DAYS_OF_THE_MONTH_ARGUMENT = "daysOfTheMonth"
-    private val MONTHS_OF_THE_YEAR_ARGUMENT = "monthsOfTheYear"
-    private val WEEKS_OF_THE_YEAR_ARGUMENT = "weeksOfTheYear"
-    private val SET_POSITIONS_ARGUMENT = "setPositions"
+    private val calendarIdArgument = "calendarId"
+    private val calendarEventsStartDateArgument = "startDate"
+    private val calendarEventsEndDateArgument = "endDate"
+    private val calendarEventIdsArgument = "eventIds"
+    private val eventIdArgument = "eventId"
+    private val eventTitleArgument = "eventTitle"
+    private val eventDescriptionArgument = "eventDescription"
+    private val eventStartDateArgument = "eventStartDate"
+    private val eventEndDateArgument = "eventEndDate"
+    private val recurrenceRuleArgument = "recurrenceRule"
+    private val recurrenceFrequencyArgument = "recurrenceFrequency"
+    private val totalOccurrencesArgument = "totalOccurrences"
+    private val intervalArgument = "interval"
+    private val endDateArgument = "endDate"
+    private val daysOfTheWeekArgument = "daysOfTheWeek"
+    private val daysOfTheMonthArgument = "daysOfTheMonth"
+    private val monthsOfTheYearArgument = "monthsOfTheYear"
+    private val weeksOfTheYearArgument = "weeksOfTheYear"
+    private val setPositionsArgument = "setPositions"
 
 
     private constructor(registrar: Registrar, calendarDelegate: CalendarDelegate) : this() {
@@ -79,32 +79,32 @@ class DeviceCalendarPlugin() : MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
-            REQUEST_PERMISSIONS_METHOD -> {
+            requestPermissionsMethod -> {
                 _calendarDelegate.requestPermissions(result)
             }
-            HAS_PERMISSIONS_METHOD -> {
+            hasPermissionsMethod -> {
                 _calendarDelegate.hasPermissions(result)
             }
-            RETRIEVE_CALENDARS_METHOD -> {
+            retrieveCalendarsMethod -> {
                 _calendarDelegate.retrieveCalendars(result)
             }
-            RETRIEVE_EVENTS_METHOD -> {
-                val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
-                val startDate = call.argument<Long>(CALENDAR_EVENTS_START_DATE_ARGUMENT)
-                val endDate = call.argument<Long>(CALENDAR_EVENTS_END_DATE_ARGUMENT)
-                val eventIds = call.argument<List<String>>(CALENDAR_EVENTS_IDS_ARGUMENT) ?: listOf()
+            retrieveEventsMethod -> {
+                val calendarId = call.argument<String>(calendarIdArgument)
+                val startDate = call.argument<Long>(calendarEventsStartDateArgument)
+                val endDate = call.argument<Long>(calendarEventsEndDateArgument)
+                val eventIds = call.argument<List<String>>(calendarEventIdsArgument) ?: listOf()
 
                 _calendarDelegate.retrieveEvents(calendarId!!, startDate, endDate, eventIds, result)
             }
-            CREATE_OR_UPDATE_EVENT_METHOD -> {
-                val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
+            createOrUpdateEventMethod -> {
+                val calendarId = call.argument<String>(calendarIdArgument)
                 val event = parseEventArgs(call, calendarId)
 
                 _calendarDelegate.createOrUpdateEvent(calendarId!!, event, result)
             }
-            DELETE_EVENT_METHOD -> {
-                val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
-                val eventId = call.argument<String>(EVENT_ID_ARGUMENT)
+            deleteEventMethod -> {
+                val calendarId = call.argument<String>(calendarIdArgument)
+                val eventId = call.argument<String>(eventIdArgument)
 
                 _calendarDelegate.deleteEvent(calendarId!!, eventId!!, result)
             }
@@ -115,11 +115,11 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     }
 
     private fun parseEventArgs(call: MethodCall, calendarId: String?): Event {
-        val eventId = call.argument<String>(EVENT_ID_ARGUMENT)
-        val eventTitle = call.argument<String>(EVENT_TITLE_ARGUMENT)
-        val eventDescription = call.argument<String>(EVENT_DESCRIPTION_ARGUMENT)
-        val eventStart = call.argument<Long>(EVENT_START_DATE_ARGUMENT)
-        val eventEnd = call.argument<Long>(EVENT_END_DATE_ARGUMENT)
+        val eventId = call.argument<String>(eventIdArgument)
+        val eventTitle = call.argument<String>(eventTitleArgument)
+        val eventDescription = call.argument<String>(eventDescriptionArgument)
+        val eventStart = call.argument<Long>(eventStartDateArgument)
+        val eventEnd = call.argument<Long>(eventEndDateArgument)
 
         val event = Event()
         event.title = eventTitle
@@ -129,7 +129,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
         event.start = eventStart!!
         event.end = eventEnd!!
 
-        if (call.hasArgument(RECURRENCE_RULE_ARGUMENT) && call.argument<Map<String, Any>>(RECURRENCE_RULE_ARGUMENT) != null) {
+        if (call.hasArgument(recurrenceRuleArgument) && call.argument<Map<String, Any>>(recurrenceRuleArgument) != null) {
             val recurrenceRule = parseRecurrenceRuleArgs(call)
             event.recurrenceRule = recurrenceRule
         }
@@ -138,39 +138,39 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     }
 
     private fun parseRecurrenceRuleArgs(call: MethodCall): RecurrenceRule {
-        val recurrenceRuleArgs = call.argument<Map<String, Any>>(RECURRENCE_RULE_ARGUMENT)!!
-        val recurrenceFrequencyIndex = recurrenceRuleArgs[RECURRENCE_FREQUENCY_ARGUMENT] as Int
+        val recurrenceRuleArgs = call.argument<Map<String, Any>>(recurrenceRuleArgument)!!
+        val recurrenceFrequencyIndex = recurrenceRuleArgs[recurrenceFrequencyArgument] as Int
         val recurrenceRule = RecurrenceRule(RecurrenceFrequency.values()[recurrenceFrequencyIndex])
-        if (recurrenceRuleArgs.containsKey(TOTAL_OCCURRENCES_ARGUMENT)) {
-            recurrenceRule.totalOccurrences = recurrenceRuleArgs[TOTAL_OCCURRENCES_ARGUMENT] as Int
+        if (recurrenceRuleArgs.containsKey(totalOccurrencesArgument)) {
+            recurrenceRule.totalOccurrences = recurrenceRuleArgs[totalOccurrencesArgument] as Int
         }
 
-        if (recurrenceRuleArgs.containsKey(INTERVAL_ARGUMENT)) {
-            recurrenceRule.interval = recurrenceRuleArgs[INTERVAL_ARGUMENT] as Int
+        if (recurrenceRuleArgs.containsKey(intervalArgument)) {
+            recurrenceRule.interval = recurrenceRuleArgs[intervalArgument] as Int
         }
 
-        if (recurrenceRuleArgs.containsKey(END_DATE_ARGUMENT)) {
-            recurrenceRule.endDate = recurrenceRuleArgs[END_DATE_ARGUMENT] as Long
+        if (recurrenceRuleArgs.containsKey(endDateArgument)) {
+            recurrenceRule.endDate = recurrenceRuleArgs[endDateArgument] as Long
         }
 
-        if (recurrenceRuleArgs.containsKey(DAYS_OF_THE_WEEK_ARGUMENT)) {
-            recurrenceRule.daysOfTheWeek = recurrenceRuleArgs[DAYS_OF_THE_WEEK_ARGUMENT].toListOf<Int>()?.map { DayOfWeek.values()[it] }?.toMutableList()
+        if (recurrenceRuleArgs.containsKey(daysOfTheWeekArgument)) {
+            recurrenceRule.daysOfTheWeek = recurrenceRuleArgs[daysOfTheWeekArgument].toListOf<Int>()?.map { DayOfWeek.values()[it] }?.toMutableList()
         }
 
-        if (recurrenceRuleArgs.containsKey(DAYS_OF_THE_MONTH_ARGUMENT)) {
-            recurrenceRule.daysOfTheMonth = recurrenceRuleArgs[DAYS_OF_THE_MONTH_ARGUMENT].toMutableListOf()
+        if (recurrenceRuleArgs.containsKey(daysOfTheMonthArgument)) {
+            recurrenceRule.daysOfTheMonth = recurrenceRuleArgs[daysOfTheMonthArgument].toMutableListOf()
         }
 
-        if (recurrenceRuleArgs.containsKey(MONTHS_OF_THE_YEAR_ARGUMENT)) {
-            recurrenceRule.monthsOfTheYear = recurrenceRuleArgs[MONTHS_OF_THE_YEAR_ARGUMENT].toMutableListOf()
+        if (recurrenceRuleArgs.containsKey(monthsOfTheYearArgument)) {
+            recurrenceRule.monthsOfTheYear = recurrenceRuleArgs[monthsOfTheYearArgument].toMutableListOf()
         }
 
-        if(recurrenceRuleArgs.containsKey(WEEKS_OF_THE_YEAR_ARGUMENT)) {
-            recurrenceRule.weeksOfTheYear = recurrenceRuleArgs[WEEKS_OF_THE_YEAR_ARGUMENT].toMutableListOf()
+        if(recurrenceRuleArgs.containsKey(weeksOfTheYearArgument)) {
+            recurrenceRule.weeksOfTheYear = recurrenceRuleArgs[weeksOfTheYearArgument].toMutableListOf()
         }
 
-        if(recurrenceRuleArgs.containsKey(SET_POSITIONS_ARGUMENT)) {
-            recurrenceRule.setPositions = recurrenceRuleArgs[SET_POSITIONS_ARGUMENT].toMutableListOf()
+        if(recurrenceRuleArgs.containsKey(setPositionsArgument)) {
+            recurrenceRule.setPositions = recurrenceRuleArgs[setPositionsArgument].toMutableListOf()
         }
 
         return recurrenceRule

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -75,8 +75,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
             registrar.addRequestPermissionsResultListener(calendarDelegate)
         }
     }
-
-
+    
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             requestPermissionsMethod -> {
@@ -160,22 +159,22 @@ class DeviceCalendarPlugin() : MethodCallHandler {
             recurrenceRule.monthsOfTheYear = recurrenceRuleArgs[monthsOfTheYearArgument].toMutableListOf()
         }
 
-        if(recurrenceRuleArgs.containsKey(weeksOfTheYearArgument)) {
+        if (recurrenceRuleArgs.containsKey(weeksOfTheYearArgument)) {
             recurrenceRule.weeksOfTheYear = recurrenceRuleArgs[weeksOfTheYearArgument].toMutableListOf()
         }
 
-        if(recurrenceRuleArgs.containsKey(setPositionsArgument)) {
+        if (recurrenceRuleArgs.containsKey(setPositionsArgument)) {
             recurrenceRule.setPositions = recurrenceRuleArgs[setPositionsArgument].toMutableListOf()
         }
 
         return recurrenceRule
     }
 
-    private inline fun <reified T:Any> Any?.toListOf(): List<T>? {
+    private inline fun <reified T : Any> Any?.toListOf(): List<T>? {
         return (this as List<*>?)?.filterIsInstance<T>()?.toList()
     }
 
-    private inline fun <reified T:Any> Any?.toMutableListOf(): MutableList<T>? {
+    private inline fun <reified T : Any> Any?.toMutableListOf(): MutableList<T>? {
         return this?.toListOf<T>()?.toMutableList()
     }
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -7,11 +7,11 @@ import com.builttoroam.devicecalendar.common.RecurrenceFrequency
 import com.builttoroam.devicecalendar.models.Attendee
 import com.builttoroam.devicecalendar.models.Event
 import com.builttoroam.devicecalendar.models.RecurrenceRule
-
+import com.builttoroam.devicecalendar.models.Reminder
+import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
 const val CHANNEL_NAME = "plugins.builttoroam.com/device_calendar"
@@ -49,6 +49,8 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private val EMAIL_ADDRESS_ARGUMENT = "emailAddress"
     private val NAME_ARGUMENT = "name"
     private val IS_REQUIRED_ARGUMENT = "isRequired"
+    private val REMINDERS_ARGUMENT = "reminders"
+    private val MINUTES_ARGUMENT = "minutes"
 
     private lateinit var _registrar: Registrar
     private lateinit var _calendarDelegate: CalendarDelegate
@@ -134,6 +136,14 @@ class DeviceCalendarPlugin() : MethodCallHandler {
             val attendeesArgs = call.argument<List<Map<String, Any>>>(ATTENDEES_ARGUMENT)!!
             for (attendeeArgs in attendeesArgs) {
                 event.attendees.add(Attendee(attendeeArgs[EMAIL_ADDRESS_ARGUMENT] as String, attendeeArgs[NAME_ARGUMENT] as String?, attendeeArgs[IS_REQUIRED_ARGUMENT] as Boolean?, null, null))
+            }
+        }
+
+        if (call.hasArgument(REMINDERS_ARGUMENT) && call.argument<List<Map<String, Any>>>(REMINDERS_ARGUMENT) != null) {
+            event.reminders = mutableListOf()
+            val remindersArgs = call.argument<List<Map<String, Any>>>(REMINDERS_ARGUMENT)!!
+            for (reminderArgs in remindersArgs) {
+                event.reminders.add(Reminder(reminderArgs[MINUTES_ARGUMENT] as Int))
             }
         }
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -69,9 +69,6 @@ class DeviceCalendarPlugin() : MethodCallHandler {
             val calendarDelegate = CalendarDelegate(activity, context)
             val instance = DeviceCalendarPlugin(registrar, calendarDelegate)
 
-            val channel = MethodChannel(registrar.messenger(), "device_calendar")
-            channel.setMethodCallHandler(instance)
-
             val calendarsChannel = MethodChannel(registrar.messenger(), CHANNEL_NAME)
             calendarsChannel.setMethodCallHandler(instance)
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -2,6 +2,7 @@ package com.builttoroam.devicecalendar
 
 import android.app.Activity
 import android.content.Context
+import com.builttoroam.devicecalendar.common.DayOfWeek
 import com.builttoroam.devicecalendar.common.RecurrenceFrequency
 import com.builttoroam.devicecalendar.models.Event
 import com.builttoroam.devicecalendar.models.RecurrenceRule
@@ -44,6 +45,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private val TOTAL_OCCURRENCES_ARGUMENT = "totalOccurrences"
     private val INTERVAL_ARGUMENT = "interval"
     private val END_DATE_ARGUMENT = "endDate"
+    private val DAYS_OF_WEEK_ARGUMENT = "daysOfWeek"
 
 
     private constructor(registrar: Registrar, calendarDelegate: CalendarDelegate) : this() {
@@ -70,7 +72,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
         }
     }
 
-    override fun onMethodCall(call: MethodCall, result: Result): Unit {
+    override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             REQUEST_PERMISSIONS_METHOD -> {
                 _calendarDelegate.requestPermissions(result)
@@ -119,6 +121,13 @@ class DeviceCalendarPlugin() : MethodCallHandler {
 
                     if (recurrenceRuleArgs.containsKey(END_DATE_ARGUMENT)) {
                         recurrenceRule.endDate = recurrenceRuleArgs[END_DATE_ARGUMENT] as Long
+                    }
+
+                    if (recurrenceRuleArgs.containsKey(DAYS_OF_WEEK_ARGUMENT)) {
+                        val daysOfWeek = recurrenceRuleArgs[DAYS_OF_WEEK_ARGUMENT] as List<Int>
+                        for (dayOfWeek in daysOfWeek) {
+                            recurrenceRule.daysOfWeek.add(DayOfWeek.values()[dayOfWeek])
+                        }
                     }
 
                     event.recurrenceRule = recurrenceRule

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -133,7 +133,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
             event.attendees = mutableListOf()
             val attendeesArgs = call.argument<List<Map<String, Any>>>(ATTENDEES_ARGUMENT)!!
             for (attendeeArgs in attendeesArgs) {
-                event.attendees.add(Attendee(null, attendeeArgs[EMAIL_ADDRESS_ARGUMENT] as String, attendeeArgs[NAME_ARGUMENT] as String?, attendeeArgs[IS_REQUIRED_ARGUMENT] as Boolean?, null, null))
+                event.attendees.add(Attendee(attendeeArgs[EMAIL_ADDRESS_ARGUMENT] as String, attendeeArgs[NAME_ARGUMENT] as String?, attendeeArgs[IS_REQUIRED_ARGUMENT] as Boolean?, null, null))
             }
         }
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -46,6 +46,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private val INTERVAL_ARGUMENT = "interval"
     private val END_DATE_ARGUMENT = "endDate"
     private val DAYS_OF_THE_WEEK_ARGUMENT = "daysOfTheWeek"
+    private val DAYS_OF_THE_MONTH_ARGUMENT = "daysOfTheMonth"
 
 
     private constructor(registrar: Registrar, calendarDelegate: CalendarDelegate) : this() {
@@ -128,6 +129,10 @@ class DeviceCalendarPlugin() : MethodCallHandler {
                         for (dayOfWeek in daysOfWeek) {
                             recurrenceRule.daysOfTheWeek.add(DayOfWeek.values()[dayOfWeek])
                         }
+                    }
+
+                    if(recurrenceRuleArgs.containsKey(DAYS_OF_THE_MONTH_ARGUMENT)) {
+                        recurrenceRule.daysOfTheMonth.addAll(recurrenceRuleArgs[DAYS_OF_THE_MONTH_ARGUMENT] as List<Int>)
                     }
 
                     event.recurrenceRule = recurrenceRule

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/Constants.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/Constants.kt
@@ -57,5 +57,11 @@ class Constants {
                 CalendarContract.Attendees.ATTENDEE_RELATIONSHIP,
                 CalendarContract.Attendees.ATTENDEE_STATUS
         )
+
+        const val REMINDER_MINUTES_INDEX = 1
+        val REMINDER_PROJECTION: Array<String> = arrayOf(
+                CalendarContract.Reminders.EVENT_ID,
+                CalendarContract.Reminders.MINUTES
+        )
     }
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/DayOfWeek.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/DayOfWeek.kt
@@ -1,0 +1,5 @@
+package com.builttoroam.devicecalendar.common
+
+enum class DayOfWeek {
+    SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY
+}

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/DayOfWeek.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/DayOfWeek.kt
@@ -1,5 +1,5 @@
 package com.builttoroam.devicecalendar.common
 
 enum class DayOfWeek {
-    SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY
+    SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
@@ -1,4 +1,4 @@
 package com.builttoroam.devicecalendar.models
 
-class Attendee(val eventId: Long, val emailAddress: String, val name: String?, val isRequired: Boolean, val attendanceStatus: Int, val isOrganizer: Boolean) {
+class Attendee(var eventId: Long?, val emailAddress: String, val name: String?, val isRequired: Boolean?, val attendanceStatus: Int?, val isOrganizer: Boolean?) {
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
@@ -1,4 +1,4 @@
 package com.builttoroam.devicecalendar.models
 
-class Attendee(val eventId: Long, val emailAddress: String, val name: String?, val isRequired: Boolean, val isOrganizer: Boolean) {
+class Attendee(val eventId: Long, val emailAddress: String, val name: String?, val isRequired: Boolean, val attendanceStatus: Int, val isOrganizer: Boolean) {
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
@@ -1,4 +1,4 @@
 package com.builttoroam.devicecalendar.models
 
-class Attendee(var eventId: Long?, val emailAddress: String, val name: String?, val isRequired: Boolean?, val attendanceStatus: Int?, val isOrganizer: Boolean?) {
+class Attendee(val emailAddress: String, val name: String?, val isRequired: Boolean?, val attendanceStatus: Int?, val isOrganizer: Boolean?) {
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
@@ -1,4 +1,4 @@
 package com.builttoroam.devicecalendar.models
 
-class Attendee(val eventId: Long, val emailAddress: String, val name: String?, val isOrganizer: Boolean) {
+class Attendee(val eventId: Long, val emailAddress: String, val name: String?, val isRequired: Boolean, val isOrganizer: Boolean) {
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
@@ -1,8 +1,4 @@
 package com.builttoroam.devicecalendar.models
 
-class Attendee(val name: String) {
-    var id: Long = -1
-    var eventId: Long = -1
-    var email: String? = null
-    var attendanceRequired: Boolean = false
+class Attendee(val eventId: Long, val emailAddress: String, val name: String?, val isOrganizer: Boolean) {
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
@@ -11,4 +11,5 @@ class Event {
     var location: String? = null
     var attendees: MutableList<Attendee> = mutableListOf()
     var recurrenceRule: RecurrenceRule? = null
+    var organizer: Attendee? = null
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
@@ -12,4 +12,5 @@ class Event {
     var attendees: MutableList<Attendee> = mutableListOf()
     var recurrenceRule: RecurrenceRule? = null
     var organizer: Attendee? = null
+    var reminders: MutableList<Reminder> = mutableListOf()
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
@@ -1,6 +1,7 @@
 package com.builttoroam.devicecalendar.models
 
-class Event(val title: String) {
+class Event() {
+    var title: String? = null
     var eventId: String? = null
     var calendarId: String? = null
     var description: String? = null

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
@@ -5,8 +5,8 @@ class Event {
     var eventId: String? = null
     var calendarId: String? = null
     var description: String? = null
-    var start: Long = -1
-    var end: Long = -1
+    var start: Long? = null
+    var end: Long? = null
     var allDay: Boolean = false
     var location: String? = null
     var attendees: MutableList<Attendee> = mutableListOf()

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
@@ -1,6 +1,6 @@
 package com.builttoroam.devicecalendar.models
 
-class Event() {
+class Event {
     var title: String? = null
     var eventId: String? = null
     var calendarId: String? = null

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
@@ -9,4 +9,5 @@ class RecurrenceRule(val recurrenceFrequency : RecurrenceFrequency) {
     var interval: Int? = null
     var endDate: Long? = null
     val daysOfTheWeek: MutableList<DayOfWeek> = mutableListOf()
+    val daysOfTheMonth: MutableList<Int> = mutableListOf()
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
@@ -8,6 +8,7 @@ class RecurrenceRule(val recurrenceFrequency : RecurrenceFrequency) {
     var totalOccurrences: Int? = null
     var interval: Int? = null
     var endDate: Long? = null
-    val daysOfTheWeek: MutableList<DayOfWeek> = mutableListOf()
-    val daysOfTheMonth: MutableList<Int> = mutableListOf()
+    var daysOfTheWeek: MutableList<DayOfWeek>? = null
+    var daysOfTheMonth: MutableList<Int>? = null
+    var monthsOfTheYear: MutableList<Int>? = null
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
@@ -11,4 +11,6 @@ class RecurrenceRule(val recurrenceFrequency : RecurrenceFrequency) {
     var daysOfTheWeek: MutableList<DayOfWeek>? = null
     var daysOfTheMonth: MutableList<Int>? = null
     var monthsOfTheYear: MutableList<Int>? = null
+    var weeksOfTheYear: MutableList<Int>? = null
+    var setPositions: MutableList<Int>? = null
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
@@ -8,5 +8,5 @@ class RecurrenceRule(val recurrenceFrequency : RecurrenceFrequency) {
     var totalOccurrences: Int? = null
     var interval: Int? = null
     var endDate: Long? = null
-    val daysOfWeek: MutableList<DayOfWeek> = mutableListOf()
+    val daysOfTheWeek: MutableList<DayOfWeek> = mutableListOf()
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/RecurrenceRule.kt
@@ -1,5 +1,6 @@
 package com.builttoroam.devicecalendar.models
 
+import com.builttoroam.devicecalendar.common.DayOfWeek
 import com.builttoroam.devicecalendar.common.RecurrenceFrequency
 
 
@@ -7,4 +8,5 @@ class RecurrenceRule(val recurrenceFrequency : RecurrenceFrequency) {
     var totalOccurrences: Int? = null
     var interval: Int? = null
     var endDate: Long? = null
+    val daysOfWeek: MutableList<DayOfWeek> = mutableListOf()
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Reminder.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Reminder.kt
@@ -1,0 +1,4 @@
+package com.builttoroam.devicecalendar.models
+
+class Reminder(val minutes: Int) {
+}

--- a/device_calendar/example/lib/main.dart
+++ b/device_calendar/example/lib/main.dart
@@ -3,20 +3,22 @@ import 'package:flutter/material.dart';
 import 'common/app_routes.dart';
 import 'presentation/pages/calendars.dart';
 
-void main() => runApp(new MyApp());
+void main() => runApp(MyApp());
 
 class MyApp extends StatefulWidget {
   @override
-  _MyAppState createState() => new _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(routes: {
-      AppRoutes.calendars: (context) {
-        return new CalendarsPage();
-      }
-    });
+    return MaterialApp(
+      routes: {
+        AppRoutes.calendars: (context) {
+          return CalendarsPage();
+        }
+      },
+    );
   }
 }

--- a/device_calendar/example/lib/presentation/date_time_picker.dart
+++ b/device_calendar/example/lib/presentation/date_time_picker.dart
@@ -25,8 +25,8 @@ class DateTimePicker extends StatelessWidget {
     final DateTime picked = await showDatePicker(
         context: context,
         initialDate: selectedDate,
-        firstDate: new DateTime(2015, 8),
-        lastDate: new DateTime(2101));
+        firstDate: DateTime(2015, 8),
+        lastDate: DateTime(2101));
     if (picked != null && picked != selectedDate) selectDate(picked);
   }
 
@@ -39,14 +39,16 @@ class DateTimePicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final TextStyle valueStyle = Theme.of(context).textTheme.title;
-    return new Row(
+    return Row(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: <Widget>[
-        new Expanded(
+        Expanded(
           flex: 4,
-          child: new InputDropdown(
+          child: InputDropdown(
             labelText: labelText,
-            valueText: selectedDate == null ? '': new DateFormat.yMMMd().format(selectedDate),
+            valueText: selectedDate == null
+                ? ''
+                : DateFormat.yMMMd().format(selectedDate),
             valueStyle: valueStyle,
             onPressed: () {
               _selectDate(context);
@@ -54,9 +56,9 @@ class DateTimePicker extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 12.0),
-        new Expanded(
+        Expanded(
           flex: 3,
-          child: new InputDropdown(
+          child: InputDropdown(
             valueText: selectedTime?.format(context) ?? '',
             valueStyle: valueStyle,
             onPressed: () {

--- a/device_calendar/example/lib/presentation/event_item.dart
+++ b/device_calendar/example/lib/presentation/event_item.dart
@@ -17,91 +17,91 @@ class EventItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return new GestureDetector(
+    return GestureDetector(
       onTap: () {
         _onTapped(_calendarEvent);
       },
-      child: new Card(
-        child: new Column(
+      child: Card(
+        child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
-            new Padding(
+            Padding(
               padding: const EdgeInsets.symmetric(vertical: 10.0),
-              child: new FlutterLogo(),
+              child: FlutterLogo(),
             ),
-            new ListTile(
-                title: new Text(_calendarEvent.title ?? ''),
-                subtitle: new Text(_calendarEvent.description ?? '')),
-            new Container(
-              padding: new EdgeInsets.symmetric(horizontal: 16.0),
-              child: new Column(
+            ListTile(
+                title: Text(_calendarEvent.title ?? ''),
+                subtitle: Text(_calendarEvent.description ?? '')),
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              child: Column(
                 children: <Widget>[
-                  new Align(
+                  Align(
                     alignment: Alignment.topLeft,
-                    child: new Row(
+                    child: Row(
                       children: <Widget>[
-                        new Container(
+                        Container(
                           width: _eventFieldNameWidth,
-                          child: new Text('Starts'),
+                          child: Text('Starts'),
                         ),
-                        new Text(_calendarEvent == null
+                        Text(_calendarEvent == null
                             ? ''
-                            : new DateFormat.yMd()
+                            : DateFormat.yMd()
                                 .add_jm()
                                 .format(_calendarEvent.start)),
                       ],
                     ),
                   ),
-                  new Padding(
-                    padding: new EdgeInsets.symmetric(vertical: 5.0),
+                  Padding(
+                    padding: EdgeInsets.symmetric(vertical: 5.0),
                   ),
-                  new Align(
+                  Align(
                     alignment: Alignment.topLeft,
-                    child: new Row(
+                    child: Row(
                       children: <Widget>[
-                        new Container(
+                        Container(
                           width: _eventFieldNameWidth,
-                          child: new Text('Ends'),
+                          child: Text('Ends'),
                         ),
-                        new Text(_calendarEvent.end == null
+                        Text(_calendarEvent.end == null
                             ? ''
-                            : new DateFormat.yMd()
+                            : DateFormat.yMd()
                                 .add_jm()
                                 .format(_calendarEvent.end)),
                       ],
                     ),
                   ),
-                  new SizedBox(
+                  SizedBox(
                     height: 10.0,
                   ),
-                  new Align(
+                  Align(
                     alignment: Alignment.topLeft,
-                    child: new Row(
+                    child: Row(
                       children: <Widget>[
-                        new Container(
+                        Container(
                           width: _eventFieldNameWidth,
-                          child: new Text('All day?'),
+                          child: Text('All day?'),
                         ),
-                        new Text(_calendarEvent.allDay != null &&
+                        Text(_calendarEvent.allDay != null &&
                                 _calendarEvent.allDay
                             ? 'Yes'
                             : 'No')
                       ],
                     ),
                   ),
-                  new SizedBox(
+                  SizedBox(
                     height: 10.0,
                   ),
-                  new Align(
+                  Align(
                     alignment: Alignment.topLeft,
-                    child: new Row(
+                    child: Row(
                       children: <Widget>[
-                        new Container(
+                        Container(
                           width: _eventFieldNameWidth,
-                          child: new Text('Location'),
+                          child: Text('Location'),
                         ),
-                        new Expanded(
-                          child: new Text(
+                        Expanded(
+                          child: Text(
                             _calendarEvent?.location ?? '',
                             overflow: TextOverflow.ellipsis,
                           ),
@@ -109,19 +109,19 @@ class EventItem extends StatelessWidget {
                       ],
                     ),
                   ),
-                  new SizedBox(
+                  SizedBox(
                     height: 10.0,
                   ),
-                  new Align(
+                  Align(
                     alignment: Alignment.topLeft,
-                    child: new Row(
+                    child: Row(
                       children: <Widget>[
-                        new Container(
+                        Container(
                           width: _eventFieldNameWidth,
-                          child: new Text('Attendees'),
+                          child: Text('Attendees'),
                         ),
-                        new Expanded(
-                          child: new Text(
+                        Expanded(
+                          child: Text(
                             _calendarEvent?.attendees
                                     ?.where((a) => a.name?.isNotEmpty ?? false)
                                     ?.map((a) => a.name)
@@ -136,32 +136,32 @@ class EventItem extends StatelessWidget {
                 ],
               ),
             ),
-            new ButtonTheme.bar(
-                child: new ButtonBar(
+            ButtonTheme.bar(
+                child: ButtonBar(
               children: <Widget>[
-                new IconButton(
+                IconButton(
                   onPressed: () {
                     _onTapped(_calendarEvent);
                   },
-                  icon: new Icon(Icons.edit),
+                  icon: Icon(Icons.edit),
                 ),
-                new IconButton(
+                IconButton(
                   onPressed: () async {
                     await showDialog<Null>(
                         context: context,
                         barrierDismissible: false,
                         builder: (BuildContext context) {
-                          return new AlertDialog(
-                            title: new Text(
+                          return AlertDialog(
+                            title: Text(
                                 'Are you sure you want to delete this event?'),
                             actions: <Widget>[
-                              new FlatButton(
+                              FlatButton(
                                 onPressed: () {
                                   Navigator.of(context).pop();
                                 },
-                                child: new Text('Cancel'),
+                                child: Text('Cancel'),
                               ),
-                              new FlatButton(
+                              FlatButton(
                                 onPressed: () async {
                                   Navigator.of(context).pop();
                                   _onLoadingStarted();
@@ -172,13 +172,13 @@ class EventItem extends StatelessWidget {
                                   _onDeleteFinished(deleteResult.isSuccess &&
                                       deleteResult.data);
                                 },
-                                child: new Text('Ok'),
+                                child: Text('Ok'),
                               ),
                             ],
                           );
                         });
                   },
-                  icon: new Icon(Icons.delete),
+                  icon: Icon(Icons.delete),
                 ),
               ],
             ))

--- a/device_calendar/example/lib/presentation/input_dropdown.dart
+++ b/device_calendar/example/lib/presentation/input_dropdown.dart
@@ -18,19 +18,19 @@ class InputDropdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return new InkWell(
+    return InkWell(
       onTap: onPressed,
-      child: new InputDecorator(
-        decoration: new InputDecoration(
+      child: InputDecorator(
+        decoration: InputDecoration(
           labelText: labelText,
         ),
         baseStyle: valueStyle,
-        child: new Row(
+        child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            new Text(valueText, style: valueStyle),
-            new Icon(Icons.arrow_drop_down,
+            Text(valueText, style: valueStyle),
+            Icon(Icons.arrow_drop_down,
                 color: Theme.of(context).brightness == Brightness.light
                     ? Colors.grey.shade700
                     : Colors.white70),

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -289,7 +289,6 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                 _recurrenceFrequency,
                 interval: _interval,
                 totalOccurrences: _totalOccurrences,
-                daysOfWeek: [DayOfWeek.Monday],
                 endDate: _recurrenceRuleEndType ==
                         RecurrenceRuleEndType.SpecifiedEndDate
                     ? _combineDateWithTime(

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -80,232 +80,235 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        key: _scaffoldKey,
-        appBar: AppBar(
-          title: Text(_event.eventId?.isEmpty ?? true
-              ? 'Create  event'
-              : 'Edit event ${_event.title}'),
-        ),
-        body: SingleChildScrollView(
-          child: Column(
-            children: <Widget>[
-              Form(
-                autovalidate: _autovalidate,
-                key: _formKey,
-                child: Column(
-                  children: <Widget>[
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: TextFormField(
-                        initialValue: _event.title,
-                        decoration: const InputDecoration(
-                            labelText: 'Title',
-                            hintText: 'Meeting with Gloria...'),
-                        validator: _validateTitle,
-                        onSaved: (String value) {
-                          _event.title = value;
-                        },
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: TextFormField(
-                        initialValue: _event.description,
-                        decoration: const InputDecoration(
-                            labelText: 'Description',
-                            hintText: 'Remember to buy flowers...'),
-                        onSaved: (String value) {
-                          _event.description = value;
-                        },
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: DateTimePicker(
-                        labelText: 'From',
-                        selectedDate: _startDate,
-                        selectedTime: _startTime,
-                        selectDate: (DateTime date) {
-                          setState(() {
-                            _startDate = date;
-                            _event.start =
-                                _combineDateWithTime(_startDate, _startTime);
-                          });
-                        },
-                        selectTime: (TimeOfDay time) {
-                          setState(
-                            () {
-                              _startTime = time;
-                              _event.start =
-                                  _combineDateWithTime(_startDate, _startTime);
-                            },
-                          );
-                        },
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: DateTimePicker(
-                        labelText: 'To',
-                        selectedDate: _endDate,
-                        selectedTime: _endTime,
-                        selectDate: (DateTime date) {
-                          setState(
-                            () {
-                              _endDate = date;
-                              _event.end =
-                                  _combineDateWithTime(_endDate, _endTime);
-                            },
-                          );
-                        },
-                        selectTime: (TimeOfDay time) {
-                          setState(
-                            () {
-                              _endTime = time;
-                              _event.end =
-                                  _combineDateWithTime(_endDate, _endTime);
-                            },
-                          );
-                        },
-                      ),
-                    ),
-                    CheckboxListTile(
-                      value: _isRecurringEvent,
-                      title: Text('Is recurring'),
-                      onChanged: (isChecked) {
-                        setState(() {
-                          _isRecurringEvent = isChecked;
-                        });
+      key: _scaffoldKey,
+      appBar: AppBar(
+        title: Text(_event.eventId?.isEmpty ?? true
+            ? 'Create  event'
+            : 'Edit event ${_event.title}'),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: <Widget>[
+            Form(
+              autovalidate: _autovalidate,
+              key: _formKey,
+              child: Column(
+                children: <Widget>[
+                  Padding(
+                    padding: const EdgeInsets.all(10.0),
+                    child: TextFormField(
+                      initialValue: _event.title,
+                      decoration: const InputDecoration(
+                          labelText: 'Title',
+                          hintText: 'Meeting with Gloria...'),
+                      validator: _validateTitle,
+                      onSaved: (String value) {
+                        _event.title = value;
                       },
                     ),
-                    if (_isRecurringEvent)
-                      Column(
-                        children: [
-                          ListTile(
-                            leading: Text('Frequency'),
-                            trailing: DropdownButton<RecurrenceFrequency>(
-                              onChanged: (selectedFrequency) {
-                                setState(() {
-                                  _recurrenceFrequency = selectedFrequency;
-                                });
-                              },
-                              value: _recurrenceFrequency,
-                              items: RecurrenceFrequency.values
-                                  .map(
-                                    (f) => DropdownMenuItem(
-                                      value: f,
-                                      child: _recurrenceFrequencyToText(f),
-                                    ),
-                                  )
-                                  .toList(),
-                            ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(10.0),
+                    child: TextFormField(
+                      initialValue: _event.description,
+                      decoration: const InputDecoration(
+                          labelText: 'Description',
+                          hintText: 'Remember to buy flowers...'),
+                      onSaved: (String value) {
+                        _event.description = value;
+                      },
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(10.0),
+                    child: DateTimePicker(
+                      labelText: 'From',
+                      selectedDate: _startDate,
+                      selectedTime: _startTime,
+                      selectDate: (DateTime date) {
+                        setState(() {
+                          _startDate = date;
+                          _event.start =
+                              _combineDateWithTime(_startDate, _startTime);
+                        });
+                      },
+                      selectTime: (TimeOfDay time) {
+                        setState(
+                          () {
+                            _startTime = time;
+                            _event.start =
+                                _combineDateWithTime(_startDate, _startTime);
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(10.0),
+                    child: DateTimePicker(
+                      labelText: 'To',
+                      selectedDate: _endDate,
+                      selectedTime: _endTime,
+                      selectDate: (DateTime date) {
+                        setState(
+                          () {
+                            _endDate = date;
+                            _event.end =
+                                _combineDateWithTime(_endDate, _endTime);
+                          },
+                        );
+                      },
+                      selectTime: (TimeOfDay time) {
+                        setState(
+                          () {
+                            _endTime = time;
+                            _event.end =
+                                _combineDateWithTime(_endDate, _endTime);
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  CheckboxListTile(
+                    value: _isRecurringEvent,
+                    title: Text('Is recurring'),
+                    onChanged: (isChecked) {
+                      setState(() {
+                        _isRecurringEvent = isChecked;
+                      });
+                    },
+                  ),
+                  if (_isRecurringEvent)
+                    Column(
+                      children: [
+                        ListTile(
+                          leading: Text('Frequency'),
+                          trailing: DropdownButton<RecurrenceFrequency>(
+                            onChanged: (selectedFrequency) {
+                              setState(() {
+                                _recurrenceFrequency = selectedFrequency;
+                              });
+                            },
+                            value: _recurrenceFrequency,
+                            items: RecurrenceFrequency.values
+                                .map(
+                                  (f) => DropdownMenuItem(
+                                    value: f,
+                                    child: _recurrenceFrequencyToText(f),
+                                  ),
+                                )
+                                .toList(),
                           ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.all(10.0),
+                          child: TextFormField(
+                            initialValue: _interval?.toString(),
+                            decoration: const InputDecoration(
+                                labelText: 'Interval between events',
+                                hintText: '1'),
+                            keyboardType: TextInputType.number,
+                            validator: _validateInterval,
+                            onSaved: (String value) {
+                              _interval = int.tryParse(value);
+                            },
+                          ),
+                        ),
+                        ListTile(
+                          leading: Text('Event ends'),
+                          trailing: DropdownButton<RecurrenceRuleEndType>(
+                            onChanged: (value) {
+                              setState(() {
+                                _recurrenceRuleEndType = value;
+                              });
+                            },
+                            value: _recurrenceRuleEndType,
+                            items: RecurrenceRuleEndType.values
+                                .map(
+                                  (f) => DropdownMenuItem(
+                                    value: f,
+                                    child: _recurrenceRuleEndTypeToText(f),
+                                  ),
+                                )
+                                .toList(),
+                          ),
+                        ),
+                        if (_recurrenceRuleEndType ==
+                            RecurrenceRuleEndType.MaxOccurrences)
                           Padding(
                             padding: const EdgeInsets.all(10.0),
                             child: TextFormField(
-                              initialValue: _interval?.toString(),
+                              initialValue: _totalOccurrences?.toString(),
                               decoration: const InputDecoration(
-                                  labelText: 'Interval between events',
-                                  hintText: '1'),
+                                  labelText: 'Max occurrences', hintText: '1'),
                               keyboardType: TextInputType.number,
-                              validator: _validateInterval,
+                              validator: _validateTotalOccurrences,
                               onSaved: (String value) {
-                                _interval = int.tryParse(value);
+                                _totalOccurrences = int.tryParse(value);
                               },
                             ),
                           ),
-                          ListTile(
-                            leading: Text('Event ends'),
-                            trailing: DropdownButton<RecurrenceRuleEndType>(
-                              onChanged: (value) {
+                        if (_recurrenceRuleEndType ==
+                            RecurrenceRuleEndType.SpecifiedEndDate)
+                          Padding(
+                            padding: const EdgeInsets.all(10.0),
+                            child: DateTimePicker(
+                              labelText: 'Date',
+                              selectedDate: _recurrenceEndDate,
+                              selectedTime: _recurrenceEndTime,
+                              selectDate: (DateTime date) {
                                 setState(() {
-                                  _recurrenceRuleEndType = value;
+                                  _recurrenceEndDate = date;
                                 });
                               },
-                              value: _recurrenceRuleEndType,
-                              items: RecurrenceRuleEndType.values
-                                  .map(
-                                    (f) => DropdownMenuItem(
-                                      value: f,
-                                      child: _recurrenceRuleEndTypeToText(f),
-                                    ),
-                                  )
-                                  .toList(),
+                              selectTime: (TimeOfDay time) {
+                                setState(() {
+                                  _recurrenceEndTime = time;
+                                });
+                              },
                             ),
                           ),
-                          if (_recurrenceRuleEndType ==
-                              RecurrenceRuleEndType.MaxOccurrences)
-                            Padding(
-                              padding: const EdgeInsets.all(10.0),
-                              child: TextFormField(
-                                initialValue: _totalOccurrences?.toString(),
-                                decoration: const InputDecoration(
-                                    labelText: 'Max occurrences',
-                                    hintText: '1'),
-                                keyboardType: TextInputType.number,
-                                validator: _validateTotalOccurrences,
-                                onSaved: (String value) {
-                                  _totalOccurrences = int.tryParse(value);
-                                },
-                              ),
-                            ),
-                          if (_recurrenceRuleEndType ==
-                              RecurrenceRuleEndType.SpecifiedEndDate)
-                            Padding(
-                              padding: const EdgeInsets.all(10.0),
-                              child: DateTimePicker(
-                                labelText: 'Date',
-                                selectedDate: _recurrenceEndDate,
-                                selectedTime: _recurrenceEndTime,
-                                selectDate: (DateTime date) {
-                                  setState(() {
-                                    _recurrenceEndDate = date;
-                                  });
-                                },
-                                selectTime: (TimeOfDay time) {
-                                  setState(() {
-                                    _recurrenceEndTime = time;
-                                  });
-                                },
-                              ),
-                            ),
-                        ],
-                      )
-                  ],
-                ),
-              )
-            ],
-          ),
+                      ],
+                    )
+                ],
+              ),
+            )
+          ],
         ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () async {
-            final FormState form = _formKey.currentState;
-            if (!form.validate()) {
-              _autovalidate = true; // Start validating on every change.
-              showInSnackBar('Please fix the errors in red before submitting.');
-            } else {
-              form.save();
-              if (_isRecurringEvent) {
-                _event.recurrenceRule = RecurrenceRule(_recurrenceFrequency,
-                    interval: _interval,
-                    totalOccurrences: _totalOccurrences,
-                    endDate: _recurrenceRuleEndType ==
-                            RecurrenceRuleEndType.SpecifiedEndDate
-                        ? _combineDateWithTime(
-                            _recurrenceEndDate, _recurrenceEndTime)
-                        : null);
-              }
-              var createEventResult =
-                  await _deviceCalendarPlugin.createOrUpdateEvent(_event);
-              if (createEventResult.isSuccess) {
-                Navigator.pop(context, true);
-              } else {
-                showInSnackBar(createEventResult.errorMessages.join(' | '));
-              }
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final FormState form = _formKey.currentState;
+          if (!form.validate()) {
+            _autovalidate = true; // Start validating on every change.
+            showInSnackBar('Please fix the errors in red before submitting.');
+          } else {
+            form.save();
+            if (_isRecurringEvent) {
+              _event.recurrenceRule = RecurrenceRule(
+                _recurrenceFrequency,
+                interval: _interval,
+                totalOccurrences: _totalOccurrences,
+                daysOfWeek: [DayOfWeek.Monday],
+                endDate: _recurrenceRuleEndType ==
+                        RecurrenceRuleEndType.SpecifiedEndDate
+                    ? _combineDateWithTime(
+                        _recurrenceEndDate, _recurrenceEndTime)
+                    : null,
+              );
             }
-          },
-          child: Icon(Icons.check),
-        ));
+            var createEventResult =
+                await _deviceCalendarPlugin.createOrUpdateEvent(_event);
+            if (createEventResult.isSuccess) {
+              Navigator.pop(context, true);
+            } else {
+              showInSnackBar(createEventResult.errorMessages.join(' | '));
+            }
+          }
+        },
+        child: Icon(Icons.check),
+      ),
+    );
   }
 
   Text _recurrenceFrequencyToText(RecurrenceFrequency recurrenceFrequency) {

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -36,7 +36,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
   bool _isRecurringEvent = false;
   RecurrenceRuleEndType _recurrenceRuleEndType;
 
-  List<DayOfWeek> _daysOfWeek = List<DayOfWeek>();
+  List<DayOfWeek> _daysOfTheWeek = List<DayOfWeek>();
 
   int _totalOccurrences;
   int _interval;
@@ -68,7 +68,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
           _recurrenceEndDate = _event.recurrenceRule.endDate;
           _recurrenceEndTime = TimeOfDay.fromDateTime(_recurrenceEndDate);
         }
-        _daysOfWeek = _event.recurrenceRule.daysOfWeek;
+        _daysOfTheWeek = _event.recurrenceRule.daysOfTheWeek;
       }
     }
 
@@ -243,14 +243,15 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                           (d) {
                             return CheckboxListTile(
                               title: _dayOfWeekToText(d),
-                              value: _daysOfWeek?.any((dow) => dow == d),
+                              value: _daysOfTheWeek?.any((dow) => dow == d) ??
+                                  false,
                               onChanged: (selected) {
                                 setState(
                                   () {
                                     if (selected) {
-                                      _daysOfWeek.add(d);
+                                      _daysOfTheWeek.add(d);
                                     } else {
-                                      _daysOfWeek.remove(d);
+                                      _daysOfTheWeek.remove(d);
                                     }
                                   },
                                 );
@@ -319,7 +320,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                     ? _combineDateWithTime(
                         _recurrenceEndDate, _recurrenceEndTime)
                     : null,
-                daysOfWeek: _daysOfWeek,
+                daysOfTheWeek: _daysOfTheWeek,
               );
             }
             var createEventResult =

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -78,6 +78,10 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
       _startDate = _event.start;
       _endDate = _event.end;
       _isRecurringEvent = _event.recurrenceRule != null;
+      if (_event.organizer != null) {
+        printAttendeeDetails(_event.organizer);
+      }
+      _event.attendees?.forEach((a) => printAttendeeDetails(a));
       if (_isRecurringEvent) {
         _interval = _event.recurrenceRule.interval;
         _totalOccurrences = _event.recurrenceRule.totalOccurrences;
@@ -105,6 +109,15 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
       _recurrenceEndTime = TimeOfDay(
           hour: _recurrenceEndDate.hour, minute: _recurrenceEndDate.minute);
     }
+  }
+
+  void printAttendeeDetails(Attendee attendee) {
+    print(
+        'attendee name: ${attendee.name}, email address: ${attendee.emailAddress}');
+    print(
+        'ios specifics - status: ${attendee.iosAttendeeDetails?.attendanceStatus}, role:  ${attendee.iosAttendeeDetails?.role}');
+    print(
+        'android specifics - status ${attendee.androidAttendeeDetails?.attendanceStatus}, is required: ${attendee.androidAttendeeDetails?.isRequired}');
   }
 
   @override

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -36,6 +36,8 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
   bool _isRecurringEvent = false;
   RecurrenceRuleEndType _recurrenceRuleEndType;
 
+  List<DayOfWeek> _daysOfWeek = List<DayOfWeek>();
+
   int _totalOccurrences;
   int _interval;
   DateTime _recurrenceEndDate;
@@ -66,6 +68,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
           _recurrenceEndDate = _event.recurrenceRule.endDate;
           _recurrenceEndTime = TimeOfDay.fromDateTime(_recurrenceEndDate);
         }
+        _daysOfWeek = _event.recurrenceRule.daysOfWeek;
       }
     }
 
@@ -83,7 +86,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
       key: _scaffoldKey,
       appBar: AppBar(
         title: Text(_event.eventId?.isEmpty ?? true
-            ? 'Create  event'
+            ? 'Create event'
             : 'Edit event ${_event.title}'),
       ),
       body: SingleChildScrollView(
@@ -233,6 +236,28 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                 .toList(),
                           ),
                         ),
+                        ListTile(
+                          leading: Text('Days of week'),
+                        ),
+                        ...DayOfWeek.values.map(
+                          (d) {
+                            return CheckboxListTile(
+                              title: _dayOfWeekToText(d),
+                              value: _daysOfWeek?.any((dow) => dow == d),
+                              onChanged: (selected) {
+                                setState(
+                                  () {
+                                    if (selected) {
+                                      _daysOfWeek.add(d);
+                                    } else {
+                                      _daysOfWeek.remove(d);
+                                    }
+                                  },
+                                );
+                              },
+                            );
+                          },
+                        ),
                         if (_recurrenceRuleEndType ==
                             RecurrenceRuleEndType.MaxOccurrences)
                           Padding(
@@ -294,6 +319,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                     ? _combineDateWithTime(
                         _recurrenceEndDate, _recurrenceEndTime)
                     : null,
+                daysOfWeek: _daysOfWeek,
               );
             }
             var createEventResult =
@@ -308,6 +334,25 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
         child: Icon(Icons.check),
       ),
     );
+  }
+
+  Text _dayOfWeekToText(DayOfWeek dayOfWeek) {
+    switch (dayOfWeek) {
+      case DayOfWeek.Sunday:
+        return Text('Sunday');
+      case DayOfWeek.Monday:
+        return Text('Monday');
+      case DayOfWeek.Tuesday:
+        return Text('Tuesday');
+      case DayOfWeek.Wednesday:
+        return Text('Wednesday');
+      case DayOfWeek.Thursday:
+        return Text('Thursday');
+      case DayOfWeek.Friday:
+        return Text('Friday');
+      default:
+        return Text('');
+    }
   }
 
   Text _recurrenceFrequencyToText(RecurrenceFrequency recurrenceFrequency) {

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -82,6 +82,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
         printAttendeeDetails(_event.organizer);
       }
       _event.attendees?.forEach((a) => printAttendeeDetails(a));
+      _event.reminders?.forEach((r) => print('reminder ${r.minutes}'));
       if (_isRecurringEvent) {
         _interval = _event.recurrenceRule.interval;
         _totalOccurrences = _event.recurrenceRule.totalOccurrences;

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -54,11 +54,11 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
       _startDate = _event.start;
       _endDate = _event.end;
       _isRecurringEvent = _event.recurrenceRule != null;
-      if(_isRecurringEvent) {
+      if (_isRecurringEvent) {
         _interval = _event.recurrenceRule.interval;
         _totalOccurrences = _event.recurrenceRule.totalOccurrences;
         _recurrenceFrequency = _event.recurrenceRule.recurrenceFrequency;
-        if(_totalOccurrences != null) {
+        if (_totalOccurrences != null) {
           _recurrenceRuleEndType = RecurrenceRuleEndType.MaxOccurrences;
         }
         if (_event.recurrenceRule.endDate != null) {
@@ -66,15 +66,14 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
           _recurrenceEndDate = _event.recurrenceRule.endDate;
           _recurrenceEndTime = TimeOfDay.fromDateTime(_recurrenceEndDate);
         }
-
       }
     }
 
     _startTime = TimeOfDay(hour: _startDate.hour, minute: _startDate.minute);
     _endTime = TimeOfDay(hour: _endDate.hour, minute: _endDate.minute);
-    if(_recurrenceEndDate != null) {
-    _recurrenceEndTime = TimeOfDay(
-        hour: _recurrenceEndDate.hour, minute: _recurrenceEndDate.minute);
+    if (_recurrenceEndDate != null) {
+      _recurrenceEndTime = TimeOfDay(
+          hour: _recurrenceEndDate.hour, minute: _recurrenceEndDate.minute);
     }
   }
 
@@ -84,7 +83,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
         key: _scaffoldKey,
         appBar: AppBar(
           title: Text(_event.eventId?.isEmpty ?? true
-              ? 'Create new event'
+              ? 'Create  event'
               : 'Edit event ${_event.title}'),
         ),
         body: SingleChildScrollView(
@@ -194,9 +193,9 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                               items: RecurrenceFrequency.values
                                   .map(
                                     (f) => DropdownMenuItem(
-                                          value: f,
-                                          child: _recurrenceFrequencyToText(f),
-                                        ),
+                                      value: f,
+                                      child: _recurrenceFrequencyToText(f),
+                                    ),
                                   )
                                   .toList(),
                             ),
@@ -227,10 +226,9 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                               items: RecurrenceRuleEndType.values
                                   .map(
                                     (f) => DropdownMenuItem(
-                                          value: f,
-                                          child:
-                                              _recurrenceRuleEndTypeToText(f),
-                                        ),
+                                      value: f,
+                                      child: _recurrenceRuleEndTypeToText(f),
+                                    ),
                                   )
                                   .toList(),
                             ),
@@ -291,8 +289,11 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                 _event.recurrenceRule = RecurrenceRule(_recurrenceFrequency,
                     interval: _interval,
                     totalOccurrences: _totalOccurrences,
-                    endDate: _recurrenceRuleEndType == RecurrenceRuleEndType.SpecifiedEndDate ? _combineDateWithTime(
-                        _recurrenceEndDate, _recurrenceEndTime) : null);
+                    endDate: _recurrenceRuleEndType ==
+                            RecurrenceRuleEndType.SpecifiedEndDate
+                        ? _combineDateWithTime(
+                            _recurrenceEndDate, _recurrenceEndTime)
+                        : null);
               }
               var createEventResult =
                   await _deviceCalendarPlugin.createOrUpdateEvent(_event);

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -91,14 +91,11 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
           _recurrenceEndTime = TimeOfDay.fromDateTime(_recurrenceEndDate);
         }
         _daysOfTheWeek =
-            _event.recurrenceRule.daysOfTheWeek ?? new List<DayOfTheWeek>();
-        _daysOfTheMonth =
-            _event.recurrenceRule.daysOfTheMonth ?? new List<int>();
-        _monthsOfTheYear =
-            _event.recurrenceRule.monthsOfTheYear ?? new List<int>();
-        _weeksOfTheYear =
-            _event.recurrenceRule.weeksOfTheYear ?? new List<int>();
-        _setPositions = _event.recurrenceRule.setPositions ?? new List<int>();
+            _event.recurrenceRule.daysOfTheWeek ?? List<DayOfTheWeek>();
+        _daysOfTheMonth = _event.recurrenceRule.daysOfTheMonth ?? List<int>();
+        _monthsOfTheYear = _event.recurrenceRule.monthsOfTheYear ?? List<int>();
+        _weeksOfTheYear = _event.recurrenceRule.weeksOfTheYear ?? List<int>();
+        _setPositions = _event.recurrenceRule.setPositions ?? List<int>();
       }
     }
 

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -40,6 +40,8 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
   List<DayOfTheWeek> _daysOfTheWeek = List<DayOfTheWeek>();
   List<int> _daysOfTheMonth = List<int>();
   List<int> _validDaysOfTheMonth = List<int>();
+  List<int> _monthsOfTheYear = List<int>();
+  List<int> _validMonthsOfTheYear = List<int>();
   int _totalOccurrences;
   int _interval;
   DateTime _recurrenceEndDate;
@@ -51,6 +53,9 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
     _deviceCalendarPlugin = DeviceCalendarPlugin();
     for (var i = 1; i <= 31; i++) {
       _validDaysOfTheMonth.add(i);
+    }
+    for (var i = 1; i <= 12; i++) {
+      _validMonthsOfTheYear.add(i);
     }
     if (this._event == null) {
       _startDate = DateTime.now();
@@ -75,6 +80,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
         }
         _daysOfTheWeek = _event.recurrenceRule.daysOfTheWeek;
         _daysOfTheMonth = _event.recurrenceRule.daysOfTheMonth;
+        _monthsOfTheYear = _event.recurrenceRule.monthsOfTheYear;
       }
     }
 
@@ -246,6 +252,35 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                       : _daysOfTheMonth[0],
                                   items: _validDaysOfTheMonth
                                       .map(
+                                        (d) => DropdownMenuItem(
+                                          value: d,
+                                          child: Text(
+                                            d.toString(),
+                                          ),
+                                        ),
+                                      )
+                                      .toList(),
+                                ),
+                              ),
+                            ],
+                          ),
+                        if (_recurrenceFrequency == RecurrenceFrequency.Yearly)
+                          Column(
+                            children: [
+                              ListTile(
+                                leading: Text('Months of the year'),
+                                trailing: DropdownButton<int>(
+                                  onChanged: (value) {
+                                    setState(() {
+                                      _monthsOfTheYear.clear();
+                                      _monthsOfTheYear.add(value);
+                                    });
+                                  },
+                                  value: _monthsOfTheYear.isEmpty
+                                      ? null
+                                      : _monthsOfTheYear[0],
+                                  items: _validMonthsOfTheYear
+                                      .map(
                                         (m) => DropdownMenuItem(
                                           value: m,
                                           child: Text(
@@ -338,7 +373,8 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                           _recurrenceEndDate, _recurrenceEndTime)
                       : null,
                   daysOfTheWeek: _daysOfTheWeek,
-                  daysOfTheMonth: _daysOfTheMonth);
+                  daysOfTheMonth: _daysOfTheMonth,
+                  monthsOfTheYear: _monthsOfTheYear);
             }
             var createEventResult =
                 await _deviceCalendarPlugin.createOrUpdateEvent(_event);

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -218,25 +218,6 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                           ),
                         ),
                         ListTile(
-                          leading: Text('Event ends'),
-                          trailing: DropdownButton<RecurrenceRuleEndType>(
-                            onChanged: (value) {
-                              setState(() {
-                                _recurrenceRuleEndType = value;
-                              });
-                            },
-                            value: _recurrenceRuleEndType,
-                            items: RecurrenceRuleEndType.values
-                                .map(
-                                  (f) => DropdownMenuItem(
-                                    value: f,
-                                    child: _recurrenceRuleEndTypeToText(f),
-                                  ),
-                                )
-                                .toList(),
-                          ),
-                        ),
-                        ListTile(
                           leading: Text('Days of week'),
                         ),
                         ...DayOfWeek.values.map(
@@ -258,6 +239,25 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                               },
                             );
                           },
+                        ),
+                        ListTile(
+                          leading: Text('Event ends'),
+                          trailing: DropdownButton<RecurrenceRuleEndType>(
+                            onChanged: (value) {
+                              setState(() {
+                                _recurrenceRuleEndType = value;
+                              });
+                            },
+                            value: _recurrenceRuleEndType,
+                            items: RecurrenceRuleEndType.values
+                                .map(
+                                  (f) => DropdownMenuItem(
+                                    value: f,
+                                    child: _recurrenceRuleEndTypeToText(f),
+                                  ),
+                                )
+                                .toList(),
+                          ),
                         ),
                         if (_recurrenceRuleEndType ==
                             RecurrenceRuleEndType.MaxOccurrences)

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -337,14 +337,14 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
   }
 
   String _validateTotalOccurrences(String value) {
-    if (!value.isEmpty && int.tryParse(value) == null) {
+    if (value.isNotEmpty && int.tryParse(value) == null) {
       return 'Total occurrences needs to be a valid number';
     }
     return null;
   }
 
   String _validateInterval(String value) {
-    if (!value.isEmpty && int.tryParse(value) == null) {
+    if (value.isNotEmpty && int.tryParse(value) == null) {
       return 'Interval needs to be a valid number';
     }
     return null;

--- a/device_calendar/example/lib/presentation/pages/calendar_events.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_events.dart
@@ -13,7 +13,7 @@ class CalendarEventsPage extends StatefulWidget {
 
   @override
   _CalendarEventsPageState createState() {
-    return new _CalendarEventsPageState(_calendar);
+    return _CalendarEventsPageState(_calendar);
   }
 }
 
@@ -26,7 +26,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   bool _isLoading = true;
 
   _CalendarEventsPageState(this._calendar) {
-    _deviceCalendarPlugin = new DeviceCalendarPlugin();
+    _deviceCalendarPlugin = DeviceCalendarPlugin();
   }
 
   @override
@@ -39,16 +39,16 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   Widget build(BuildContext context) {
     final hasAnyEvents = _calendarEvents?.isNotEmpty ?? false;
     Widget body = hasAnyEvents
-        ? new Stack(
+        ? Stack(
             children: <Widget>[
-              new Column(
+              Column(
                 children: <Widget>[
-                  new Expanded(
+                  Expanded(
                     flex: 1,
-                    child: new ListView.builder(
+                    child: ListView.builder(
                       itemCount: _calendarEvents?.length ?? 0,
                       itemBuilder: (BuildContext context, int index) {
-                        return new EventItem(
+                        return EventItem(
                             _calendarEvents[index],
                             _deviceCalendarPlugin,
                             _onLoading,
@@ -59,33 +59,32 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
                   )
                 ],
               ),
-              new Offstage(
+              Offstage(
                   offstage: !_isLoading,
-                  child: new Container(
-                      decoration: new BoxDecoration(
-                          color: new Color.fromARGB(155, 192, 192, 192)),
-                      child:
-                          new Center(child: new CircularProgressIndicator())))
+                  child: Container(
+                      decoration: BoxDecoration(
+                          color: Color.fromARGB(155, 192, 192, 192)),
+                      child: Center(child: CircularProgressIndicator())))
             ],
           )
-        : new Center(child: new Text('No events found'));
-    return new Scaffold(
-      appBar: new AppBar(title: new Text('${_calendar.name} events')),
-      body: new Builder(builder: (BuildContext context) {
+        : Center(child: Text('No events found'));
+    return Scaffold(
+      appBar: AppBar(title: Text('${_calendar.name} events')),
+      body: Builder(builder: (BuildContext context) {
         _scaffoldContext = context;
         return body;
       }),
-      floatingActionButton: new FloatingActionButton(
+      floatingActionButton: FloatingActionButton(
         onPressed: () async {
           final refreshEvents = await Navigator.push(context,
-              new MaterialPageRoute(builder: (BuildContext context) {
-            return new CalendarEventPage(_calendar);
+              MaterialPageRoute(builder: (BuildContext context) {
+            return CalendarEventPage(_calendar);
           }));
           if (refreshEvents == true) {
             _retrieveCalendarEvents();
           }
         },
-        child: new Icon(Icons.add),
+        child: Icon(Icons.add),
       ),
     );
   }
@@ -100,11 +99,11 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     if (deleteSucceeded) {
       await _retrieveCalendarEvents();
     } else {
-      Scaffold.of(_scaffoldContext).showSnackBar(new SnackBar(
-            content: new Text('Oops, we ran into an issue deleting the event'),
-            backgroundColor: Colors.red,
-            duration: new Duration(seconds: 5),
-          ));
+      Scaffold.of(_scaffoldContext).showSnackBar(SnackBar(
+        content: Text('Oops, we ran into an issue deleting the event'),
+        backgroundColor: Colors.red,
+        duration: Duration(seconds: 5),
+      ));
       setState(() {
         _isLoading = false;
       });
@@ -113,8 +112,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
 
   Future _onTapped(Event event) async {
     final refreshEvents = await Navigator.push(context,
-        new MaterialPageRoute(builder: (BuildContext context) {
-      return new CalendarEventPage(_calendar, event);
+        MaterialPageRoute(builder: (BuildContext context) {
+      return CalendarEventPage(_calendar, event);
     }));
     if (refreshEvents != null && refreshEvents) {
       _retrieveCalendarEvents();
@@ -122,11 +121,11 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   }
 
   Future _retrieveCalendarEvents() async {
-    final startDate = new DateTime.now().add(new Duration(days: -30));
-    final endDate = new DateTime.now().add(new Duration(days: 30));
+    final startDate = DateTime.now().add(Duration(days: -30));
+    final endDate = DateTime.now().add(Duration(days: 30));
     var calendarEventsResult = await _deviceCalendarPlugin.retrieveEvents(
         _calendar.id,
-        new RetrieveEventsParams(startDate: startDate, endDate: endDate));
+        RetrieveEventsParams(startDate: startDate, endDate: endDate));
     setState(() {
       _calendarEvents = calendarEventsResult?.data;
       _isLoading = false;

--- a/device_calendar/example/lib/presentation/pages/calendars.dart
+++ b/device_calendar/example/lib/presentation/pages/calendars.dart
@@ -7,7 +7,7 @@ import 'calendar_events.dart';
 class CalendarsPage extends StatefulWidget {
   @override
   _CalendarsPageState createState() {
-    return new _CalendarsPageState();
+    return _CalendarsPageState();
   }
 }
 
@@ -16,7 +16,7 @@ class _CalendarsPageState extends State<CalendarsPage> {
   List<Calendar> _calendars;
 
   _CalendarsPageState() {
-    _deviceCalendarPlugin = new DeviceCalendarPlugin();
+    _deviceCalendarPlugin = DeviceCalendarPlugin();
   }
 
   @override
@@ -27,36 +27,36 @@ class _CalendarsPageState extends State<CalendarsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return new Scaffold(
-      appBar: new AppBar(
-        title: new Text('Calendars'),
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Calendars'),
       ),
-      body: new Column(
+      body: Column(
         children: <Widget>[
-          new Expanded(
+          Expanded(
             flex: 1,
-            child: new ListView.builder(
+            child: ListView.builder(
               itemCount: _calendars?.length ?? 0,
               itemBuilder: (BuildContext context, int index) {
-                return new GestureDetector(
+                return GestureDetector(
                     onTap: () async {
-                      await Navigator.push(context, new MaterialPageRoute(
-                          builder: (BuildContext context) {
-                        return new CalendarEventsPage(_calendars[index]);
+                      await Navigator.push(context,
+                          MaterialPageRoute(builder: (BuildContext context) {
+                        return CalendarEventsPage(_calendars[index]);
                       }));
                     },
-                    child: new Padding(
+                    child: Padding(
                         padding: const EdgeInsets.all(10.0),
-                        child: new Row(
+                        child: Row(
                           children: <Widget>[
-                            new Expanded(
+                            Expanded(
                               flex: 1,
-                              child: new Text(
+                              child: Text(
                                 _calendars[index].name,
-                                style: new TextStyle(fontSize: 25.0),
+                                style: TextStyle(fontSize: 25.0),
                               ),
                             ),
-                            new Icon(_calendars[index].isReadOnly
+                            Icon(_calendars[index].isReadOnly
                                 ? Icons.lock
                                 : Icons.lock_open)
                           ],

--- a/device_calendar/example/lib/presentation/pages/calendars.dart
+++ b/device_calendar/example/lib/presentation/pages/calendars.dart
@@ -32,7 +32,14 @@ class _CalendarsPageState extends State<CalendarsPage> {
         title: Text('Calendars'),
       ),
       body: Column(
-        children: <Widget>[
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(10.0),
+            child: Text(
+              'WARNING: some aspects of saving events are hardcoded in this example app. As such we recommend you do not modify existing events as this may result in loss of information',
+              style: Theme.of(context).textTheme.title,
+            ),
+          ),
           Expanded(
             flex: 1,
             child: ListView.builder(
@@ -53,7 +60,7 @@ class _CalendarsPageState extends State<CalendarsPage> {
                               flex: 1,
                               child: Text(
                                 _calendars[index].name,
-                                style: TextStyle(fontSize: 25.0),
+                                style: Theme.of(context).textTheme.subhead,
                               ),
                             ),
                             Icon(_calendars[index].isReadOnly

--- a/device_calendar/example/lib/presentation/pages/event_attendees.dart
+++ b/device_calendar/example/lib/presentation/pages/event_attendees.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:device_calendar/device_calendar.dart';
+
+class EventAttendees extends StatefulWidget {
+  final List<Attendee> _attendees;
+  const EventAttendees(this._attendees, {Key key}) : super(key: key);
+
+  @override
+  _EventAttendeesState createState() =>
+      _EventAttendeesState(_attendees ?? List<Attendee>());
+}
+
+class _EventAttendeesState extends State<EventAttendees> {
+  List<Attendee> _attendees;
+  final _formKey = GlobalKey<FormState>();
+  final _emailAddressController = TextEditingController();
+
+  _EventAttendeesState(List<Attendee> attendees) {
+    _attendees = List<Attendee>()..addAll(attendees);
+  }
+
+  @override
+  void dispose() {
+    _emailAddressController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Attendees'),
+      ),
+      body: Column(
+        children: [
+          Form(
+            key: _formKey,
+            child: Padding(
+              padding: const EdgeInsets.all(10.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: _emailAddressController,
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Please enter an email address';
+                        }
+                        return null;
+                      },
+                      decoration:
+                          const InputDecoration(labelText: 'Email address'),
+                    ),
+                  ),
+                  RaisedButton(
+                    child: Text('Add'),
+                    onPressed: () {
+                      if (_formKey.currentState.validate()) {
+                        setState(() {
+                          _attendees.add(Attendee(
+                              emailAddress: _emailAddressController.text));
+                          _emailAddressController.clear();
+                        });
+                      }
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _attendees.length,
+              itemBuilder: (context, index) {
+                return ListTile(
+                  title: Text('${_attendees[index].emailAddress}'),
+                  trailing: RaisedButton(
+                    onPressed: () {
+                      setState(() {
+                        _attendees.removeWhere((a) =>
+                            a.emailAddress == _attendees[index].emailAddress);
+                      });
+                    },
+                    child: Text('Delete'),
+                  ),
+                );
+              },
+            ),
+          ),
+          RaisedButton(
+            onPressed: () {
+              Navigator.pop(context, _attendees);
+            },
+            child: Text('Done'),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/device_calendar/example/lib/presentation/pages/event_reminders.dart
+++ b/device_calendar/example/lib/presentation/pages/event_reminders.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:device_calendar/device_calendar.dart';
+
+class EventReminders extends StatefulWidget {
+  final List<Reminder> _reminders;
+  EventReminders(this._reminders, {Key key}) : super(key: key);
+
+  _EventRemindersState createState() => _EventRemindersState(_reminders);
+}
+
+class _EventRemindersState extends State<EventReminders> {
+  List<Reminder> _reminders;
+  final _formKey = GlobalKey<FormState>();
+  final _minutesController = TextEditingController();
+
+  _EventRemindersState(List<Reminder> reminders) {
+    _reminders = List<Reminder>()..addAll(reminders);
+  }
+
+  @override
+  void dispose() {
+    _minutesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Reminders'),
+      ),
+      body: Column(
+        children: [
+          Form(
+            key: _formKey,
+            child: Padding(
+              padding: const EdgeInsets.all(10.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: _minutesController,
+                      validator: (value) {
+                        if (value == null ||
+                            value.isEmpty ||
+                            int.tryParse(value) == null) {
+                          return 'Please enter a reminder time in minutes';
+                        }
+                        return null;
+                      },
+                      decoration: const InputDecoration(
+                          labelText: 'Minutes before start'),
+                    ),
+                  ),
+                  RaisedButton(
+                    child: Text('Add'),
+                    onPressed: () {
+                      if (_formKey.currentState.validate()) {
+                        setState(() {
+                          _reminders.add(Reminder(
+                              minutes: int.parse(_minutesController.text)));
+                          _minutesController.clear();
+                        });
+                      }
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _reminders.length,
+              itemBuilder: (context, index) {
+                return ListTile(
+                  title: Text('${_reminders[index].minutes} minutes'),
+                  trailing: RaisedButton(
+                    onPressed: () {
+                      setState(() {
+                        _reminders.removeWhere(
+                            (a) => a.minutes == _reminders[index].minutes);
+                      });
+                    },
+                    child: Text('Delete'),
+                  ),
+                );
+              },
+            ),
+          ),
+          RaisedButton(
+            onPressed: () {
+              Navigator.pop(context, _reminders);
+            },
+            child: Text('Done'),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/device_calendar/example/lib/presentation/widgets/days_of_the_week_form_entry.dart
+++ b/device_calendar/example/lib/presentation/widgets/days_of_the_week_form_entry.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:device_calendar/device_calendar.dart';
+
+class DaysOfTheWeekFormEntry extends StatefulWidget {
+  final List<DayOfTheWeek> daysOfTheWeek;
+  const DaysOfTheWeekFormEntry({@required this.daysOfTheWeek, Key key})
+      : super(key: key);
+
+  @override
+  _DaysOfTheWeekFormEntryState createState() => _DaysOfTheWeekFormEntryState();
+}
+
+class _DaysOfTheWeekFormEntryState extends State<DaysOfTheWeekFormEntry> {
+  Text _dayOfWeekToText(DayOfTheWeek dayOfWeek) {
+    switch (dayOfWeek) {
+      case DayOfTheWeek.Sunday:
+        return Text('Sunday');
+      case DayOfTheWeek.Monday:
+        return Text('Monday');
+      case DayOfTheWeek.Tuesday:
+        return Text('Tuesday');
+      case DayOfTheWeek.Wednesday:
+        return Text('Wednesday');
+      case DayOfTheWeek.Thursday:
+        return Text('Thursday');
+      case DayOfTheWeek.Friday:
+        return Text('Friday');
+      default:
+        return Text('');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ListTile(
+          leading: Text('Days of the week'),
+        ),
+        ...DayOfTheWeek.values.map(
+          (d) {
+            return CheckboxListTile(
+              title: _dayOfWeekToText(d),
+              value: widget.daysOfTheWeek?.any((dow) => dow == d) ?? false,
+              onChanged: (selected) {
+                setState(
+                  () {
+                    if (selected) {
+                      widget.daysOfTheWeek.add(d);
+                    } else {
+                      widget.daysOfTheWeek.remove(d);
+                    }
+                  },
+                );
+              },
+            );
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/device_calendar/example/lib/presentation/widgets/days_of_the_week_form_entry.dart
+++ b/device_calendar/example/lib/presentation/widgets/days_of_the_week_form_entry.dart
@@ -25,6 +25,8 @@ class _DaysOfTheWeekFormEntryState extends State<DaysOfTheWeekFormEntry> {
         return Text('Thursday');
       case DayOfTheWeek.Friday:
         return Text('Friday');
+      case DayOfTheWeek.Saturday:
+        return Text('Saturday');
       default:
         return Text('');
     }

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -224,8 +224,8 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 frequency = 0
             }
             
-            var totalOccurrences: Int? = nil
-            var endDate: Int64? = nil
+            var totalOccurrences: Int?
+            var endDate: Int64?
             if(ekRecurrenceRule.recurrenceEnd?.occurrenceCount != nil) {
                 totalOccurrences = ekRecurrenceRule.recurrenceEnd?.occurrenceCount
             }
@@ -235,7 +235,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 endDate = Int64(exactly: endDateMs!)
             }
             
-            var daysOfTheWeek: [Int]? = nil
+            var daysOfTheWeek: [Int]?
             if(ekRecurrenceRule.daysOfTheWeek != nil && !ekRecurrenceRule.daysOfTheWeek!.isEmpty) {
                 daysOfTheWeek = []
                 for dayOfTheWeek in ekRecurrenceRule.daysOfTheWeek! {
@@ -243,7 +243,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 }
             }
             
-            var daysOfTheMonth: [Int]? = nil
+            var daysOfTheMonth: [Int]?
             if(ekRecurrenceRule.daysOfTheMonth != nil && !ekRecurrenceRule.daysOfTheMonth!.isEmpty) {
                 daysOfTheMonth = []
                 for dayOfTheMonth in ekRecurrenceRule.daysOfTheMonth! {
@@ -251,7 +251,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 }
             }
             
-            var monthsOfTheYear: [Int]? = nil
+            var monthsOfTheYear: [Int]?
             if(ekRecurrenceRule.monthsOfTheYear != nil && !ekRecurrenceRule.monthsOfTheYear!.isEmpty) {
                 monthsOfTheYear = []
                 for monthOfTheYear in ekRecurrenceRule.monthsOfTheYear! {
@@ -259,7 +259,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 }
             }
             
-            var weeksOfTheYear: [Int]? = nil
+            var weeksOfTheYear: [Int]?
             if(ekRecurrenceRule.weeksOfTheYear != nil && !ekRecurrenceRule.weeksOfTheYear!.isEmpty) {
                 weeksOfTheYear = []
                 for weekOfTheYear in ekRecurrenceRule.weeksOfTheYear! {
@@ -267,7 +267,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 }
             }
             
-            var setPositions: [Int]? = nil
+            var setPositions: [Int]?
             if(ekRecurrenceRule.setPositions != nil && !ekRecurrenceRule.setPositions!.isEmpty) {
                 setPositions = []
                 for setPosition in ekRecurrenceRule.setPositions! {
@@ -305,7 +305,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         }
         
         let daysOfTheWeekIndices = recurrenceRuleArguments![daysOfTheWeekArgument] as? [Int]
-        var daysOfTheWeek : [EKRecurrenceDayOfWeek]? = nil
+        var daysOfTheWeek : [EKRecurrenceDayOfWeek]?
         
         if(daysOfTheWeekIndices != nil && !daysOfTheWeekIndices!.isEmpty) {
             daysOfTheWeek = []

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -83,7 +83,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
     let weeksOfTheYearArgument = "weeksOfTheYear"
     let setPositionsArgument = "setPositions"
     let validFrequencyTypes = [EKRecurrenceFrequency.daily, EKRecurrenceFrequency.weekly, EKRecurrenceFrequency.monthly, EKRecurrenceFrequency.yearly]
-
+    
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: channelName, binaryMessenger: registrar.messenger())
@@ -243,47 +243,29 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 }
             }
             
-            var daysOfTheMonth: [Int]?
-            if(ekRecurrenceRule.daysOfTheMonth != nil && !ekRecurrenceRule.daysOfTheMonth!.isEmpty) {
-                daysOfTheMonth = []
-                for dayOfTheMonth in ekRecurrenceRule.daysOfTheMonth! {
-                    daysOfTheMonth!.append(dayOfTheMonth.intValue)
-                }
-            }
-            
-            var monthsOfTheYear: [Int]?
-            if(ekRecurrenceRule.monthsOfTheYear != nil && !ekRecurrenceRule.monthsOfTheYear!.isEmpty) {
-                monthsOfTheYear = []
-                for monthOfTheYear in ekRecurrenceRule.monthsOfTheYear! {
-                    monthsOfTheYear!.append(monthOfTheYear.intValue)
-                }
-            }
-            
-            var weeksOfTheYear: [Int]?
-            if(ekRecurrenceRule.weeksOfTheYear != nil && !ekRecurrenceRule.weeksOfTheYear!.isEmpty) {
-                weeksOfTheYear = []
-                for weekOfTheYear in ekRecurrenceRule.weeksOfTheYear! {
-                    weeksOfTheYear!.append(weekOfTheYear.intValue)
-                }
-            }
-            
-            var setPositions: [Int]?
-            if(ekRecurrenceRule.setPositions != nil && !ekRecurrenceRule.setPositions!.isEmpty) {
-                setPositions = []
-                for setPosition in ekRecurrenceRule.setPositions! {
-                    setPositions!.append(setPosition.intValue)
-                }
-            }
-            
-            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: daysOfTheMonth, monthsOfTheYear: monthsOfTheYear, weeksOfTheYear: weeksOfTheYear, setPositions: setPositions)
+            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: convertToIntArray(ekRecurrenceRule.daysOfTheMonth), monthsOfTheYear: convertToIntArray(ekRecurrenceRule.monthsOfTheYear), weeksOfTheYear: convertToIntArray(ekRecurrenceRule.weeksOfTheYear), setPositions: convertToIntArray(ekRecurrenceRule.setPositions))
         }
+        
         return recurrenceRule
+    }
+    
+    private func convertToIntArray(_ arguments: [NSNumber]?) -> [Int]? {
+        if(arguments?.isEmpty ?? true) {
+            return nil
+        }
+        
+        var result: [Int] = []
+        for element in arguments! {
+            result.append(element.intValue)
+        }
+        
+        return result
     }
     
     private func createEKRecurrenceRules(_ arguments: [String : AnyObject]) -> [EKRecurrenceRule]?{
         let recurrenceRuleArguments = arguments[recurrenceRuleArgument] as? Dictionary<String, AnyObject>
         if (recurrenceRuleArguments == nil) {
-            return nil;
+            return nil
         }
         
         let recurrenceFrequencyIndex = recurrenceRuleArguments![recurrenceFrequencyArgument] as? NSInteger

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -32,7 +32,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let totalOccurrences: Int?
         let interval: Int
         let endDate: Int64?
-        let daysOfWeek: [Int]?
+        let daysOfTheWeek: [Int]?
     }
     
     struct Attendee: Codable {
@@ -73,7 +73,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
     let recurrenceFrequencyArgument = "recurrenceFrequency"
     let totalOccurrencesArgument = "totalOccurrences"
     let intervalArgument = "interval"
-    let daysOfWeekArgument = "daysOfWeek"
+    let daysOfTheWeekArgument = "daysOfTheWeek"
     let validFrequencyTypes = [EKRecurrenceFrequency.daily, EKRecurrenceFrequency.weekly, EKRecurrenceFrequency.monthly, EKRecurrenceFrequency.yearly]
 
     
@@ -234,7 +234,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                     daysOfWeek!.append(dayOfWeek.dayOfTheWeek.rawValue - 1)
                 }
             }
-            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfWeek: daysOfWeek)
+            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfTheWeek: daysOfWeek)
         }
         return recurrenceRule
     }
@@ -263,7 +263,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
             recurrenceInterval = interval!
         }
         
-        let daysOfWeekIndices = recurrenceRuleArguments![daysOfWeekArgument] as? Array<Int>
+        let daysOfWeekIndices = recurrenceRuleArguments![daysOfTheWeekArgument] as? Array<Int>
         var daysOfWeek : [EKRecurrenceDayOfWeek]? = nil
         
         if(daysOfWeekIndices != nil) {

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -430,8 +430,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let errorMessage = String(format: self.eventNotFoundErrorMessageFormat, eventId)
         result(FlutterError(code:self.notFoundErrorCode, message: errorMessage, details: nil))
     }
-    
-    
+
     private func encodeJsonAndFinish<T: Codable>(codable: T, result: @escaping FlutterResult) {
         do {
             let jsonEncoder = JSONEncoder()

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -35,6 +35,8 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let daysOfTheWeek: [Int]?
         let daysOfTheMonth: [Int]?
         let monthsOfTheYear: [Int]?
+        let weeksOfTheYear: [Int]?
+        let setPositions: [Int]?
     }
     
     struct Attendee: Codable {
@@ -78,6 +80,8 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
     let daysOfTheWeekArgument = "daysOfTheWeek"
     let daysOfTheMonthArgument = "daysOfTheMonth"
     let monthsOfTheYearArgument = "monthsOfTheYear"
+    let weeksOfTheYearArgument = "weeksOfTheYear"
+    let setPositionsArgument = "setPositions"
     let validFrequencyTypes = [EKRecurrenceFrequency.daily, EKRecurrenceFrequency.weekly, EKRecurrenceFrequency.monthly, EKRecurrenceFrequency.yearly]
 
     
@@ -232,7 +236,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
             }
             
             var daysOfTheWeek: [Int]? = nil
-            if(ekRecurrenceRule.daysOfTheWeek != nil) {
+            if(ekRecurrenceRule.daysOfTheWeek != nil && !ekRecurrenceRule.daysOfTheWeek!.isEmpty) {
                 daysOfTheWeek = []
                 for dayOfTheWeek in ekRecurrenceRule.daysOfTheWeek! {
                     daysOfTheWeek!.append(dayOfTheWeek.dayOfTheWeek.rawValue - 1)
@@ -240,7 +244,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
             }
             
             var daysOfTheMonth: [Int]? = nil
-            if(ekRecurrenceRule.daysOfTheMonth != nil) {
+            if(ekRecurrenceRule.daysOfTheMonth != nil && !ekRecurrenceRule.daysOfTheMonth!.isEmpty) {
                 daysOfTheMonth = []
                 for dayOfTheMonth in ekRecurrenceRule.daysOfTheMonth! {
                     daysOfTheMonth!.append(dayOfTheMonth.intValue)
@@ -248,14 +252,30 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
             }
             
             var monthsOfTheYear: [Int]? = nil
-            if(ekRecurrenceRule.monthsOfTheYear != nil) {
+            if(ekRecurrenceRule.monthsOfTheYear != nil && !ekRecurrenceRule.monthsOfTheYear!.isEmpty) {
                 monthsOfTheYear = []
                 for monthOfTheYear in ekRecurrenceRule.monthsOfTheYear! {
                     monthsOfTheYear!.append(monthOfTheYear.intValue)
                 }
             }
             
-            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: daysOfTheMonth, monthsOfTheYear: monthsOfTheYear)
+            var weeksOfTheYear: [Int]? = nil
+            if(ekRecurrenceRule.weeksOfTheYear != nil && !ekRecurrenceRule.weeksOfTheYear!.isEmpty) {
+                weeksOfTheYear = []
+                for weekOfTheYear in ekRecurrenceRule.weeksOfTheYear! {
+                    weeksOfTheYear!.append(weekOfTheYear.intValue)
+                }
+            }
+            
+            var setPositions: [Int]? = nil
+            if(ekRecurrenceRule.setPositions != nil && !ekRecurrenceRule.setPositions!.isEmpty) {
+                setPositions = []
+                for setPosition in ekRecurrenceRule.setPositions! {
+                    setPositions!.append(setPosition.intValue)
+                }
+            }
+            
+            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: daysOfTheMonth, monthsOfTheYear: monthsOfTheYear, weeksOfTheYear: weeksOfTheYear, setPositions: setPositions)
         }
         return recurrenceRule
     }
@@ -287,14 +307,14 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let daysOfTheWeekIndices = recurrenceRuleArguments![daysOfTheWeekArgument] as? [Int]
         var daysOfTheWeek : [EKRecurrenceDayOfWeek]? = nil
         
-        if(daysOfTheWeekIndices != nil) {
+        if(daysOfTheWeekIndices != nil && !daysOfTheWeekIndices!.isEmpty) {
             daysOfTheWeek = []
             for dayOfWeekIndex in daysOfTheWeekIndices! {
                 daysOfTheWeek!.append(EKRecurrenceDayOfWeek.init(EKWeekday.init(rawValue: dayOfWeekIndex + 1)!))
             }
         }
         
-        return [EKRecurrenceRule(recurrenceWith: namedFrequency, interval: recurrenceInterval, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: recurrenceRuleArguments![daysOfTheMonthArgument] as? [NSNumber], monthsOfTheYear: recurrenceRuleArguments![monthsOfTheYearArgument] as? [NSNumber], weeksOfTheYear: nil, daysOfTheYear: nil, setPositions: nil, end: recurrenceEnd)]
+        return [EKRecurrenceRule(recurrenceWith: namedFrequency, interval: recurrenceInterval, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: recurrenceRuleArguments![daysOfTheMonthArgument] as? [NSNumber], monthsOfTheYear: recurrenceRuleArguments![monthsOfTheYearArgument] as? [NSNumber], weeksOfTheYear: recurrenceRuleArguments![weeksOfTheYearArgument] as? [NSNumber], daysOfTheYear: nil, setPositions: recurrenceRuleArguments![setPositionsArgument] as? [NSNumber], end: recurrenceEnd)]
     }
     
     private func createOrUpdateEvent(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -43,6 +43,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
     struct Attendee: Codable {
         let name: String?
         let emailAddress: String
+        let role: Int
     }
     
     static let channelName = "plugins.builttoroam.com/device_calendar"
@@ -205,7 +206,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         }
         
         let emailAddress = ekParticipant!.url.absoluteString.replacingOccurrences(of: ekParticipant!.url.scheme! + ":", with: "")
-        let attendee = Attendee(name: ekParticipant!.name, emailAddress:  emailAddress)
+        let attendee = Attendee(name: ekParticipant!.name, emailAddress:  emailAddress, role: ekParticipant!.participantRole.rawValue)
         return attendee
     }
     

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -7,7 +7,6 @@ extension Date {
 }
 
 public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
-    
     struct Calendar: Codable {
         let id: String
         let name: String
@@ -44,6 +43,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let name: String?
         let emailAddress: String
         let role: Int
+        let attendanceStatus: Int
     }
     
     static let channelName = "plugins.builttoroam.com/device_calendar"
@@ -206,12 +206,10 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         }
         
         let emailAddress = ekParticipant!.url.absoluteString.replacingOccurrences(of: ekParticipant!.url.scheme! + ":", with: "")
-        let attendee = Attendee(name: ekParticipant!.name, emailAddress:  emailAddress, role: ekParticipant!.participantRole.rawValue)
+        let attendee = Attendee(name: ekParticipant!.name, emailAddress:  emailAddress, role: ekParticipant!.participantRole.rawValue, attendanceStatus: ekParticipant!.participantStatus.rawValue)
         return attendee
     }
-    
-    
-    
+
     private func parseEKRecurrenceRules(_ ekEvent: EKEvent) -> RecurrenceRule? {
         var recurrenceRule: RecurrenceRule?
         if(ekEvent.hasRecurrenceRules) {

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -33,6 +33,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let interval: Int
         let endDate: Int64?
         let daysOfTheWeek: [Int]?
+        let daysOfTheMonth: [Int]?
     }
     
     struct Attendee: Codable {
@@ -74,6 +75,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
     let totalOccurrencesArgument = "totalOccurrences"
     let intervalArgument = "interval"
     let daysOfTheWeekArgument = "daysOfTheWeek"
+    let daysOfTheMonthArgument = "daysOfTheMonth"
     let validFrequencyTypes = [EKRecurrenceFrequency.daily, EKRecurrenceFrequency.weekly, EKRecurrenceFrequency.monthly, EKRecurrenceFrequency.yearly]
 
     
@@ -227,14 +229,22 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 endDate = Int64(exactly: endDateMs!)
             }
             
-            var daysOfWeek: [Int]? = nil
+            var daysOfTheWeek: [Int]? = nil
             if(ekRecurrenceRule.daysOfTheWeek != nil) {
-                daysOfWeek = []
-                for dayOfWeek in ekRecurrenceRule.daysOfTheWeek! {
-                    daysOfWeek!.append(dayOfWeek.dayOfTheWeek.rawValue - 1)
+                daysOfTheWeek = []
+                for dayOfTheWeek in ekRecurrenceRule.daysOfTheWeek! {
+                    daysOfTheWeek!.append(dayOfTheWeek.dayOfTheWeek.rawValue - 1)
                 }
             }
-            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfTheWeek: daysOfWeek)
+            
+            var daysOfTheMonth: [Int]? = nil
+            if(ekRecurrenceRule.daysOfTheMonth != nil) {
+                daysOfTheMonth = []
+                for dayOfTheMonth in ekRecurrenceRule.daysOfTheMonth! {
+                    daysOfTheMonth!.append(dayOfTheMonth.intValue)
+                }
+            }
+            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: daysOfTheMonth)
         }
         return recurrenceRule
     }
@@ -263,17 +273,20 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
             recurrenceInterval = interval!
         }
         
-        let daysOfWeekIndices = recurrenceRuleArguments![daysOfTheWeekArgument] as? Array<Int>
-        var daysOfWeek : [EKRecurrenceDayOfWeek]? = nil
+        let daysOfTheWeekIndices = recurrenceRuleArguments![daysOfTheWeekArgument] as? [Int]
+        var daysOfTheWeek : [EKRecurrenceDayOfWeek]? = nil
         
-        if(daysOfWeekIndices != nil) {
-            daysOfWeek = []
-            for dayOfWeekIndex in daysOfWeekIndices! {
-                daysOfWeek!.append(EKRecurrenceDayOfWeek.init(EKWeekday.init(rawValue: dayOfWeekIndex + 1)!))
+        if(daysOfTheWeekIndices != nil) {
+            daysOfTheWeek = []
+            for dayOfWeekIndex in daysOfTheWeekIndices! {
+                daysOfTheWeek!.append(EKRecurrenceDayOfWeek.init(EKWeekday.init(rawValue: dayOfWeekIndex + 1)!))
             }
         }
         
-        return [EKRecurrenceRule(recurrenceWith: namedFrequency, interval: recurrenceInterval, daysOfTheWeek: daysOfWeek, daysOfTheMonth: nil, monthsOfTheYear: nil, weeksOfTheYear: nil, daysOfTheYear: nil, setPositions: nil, end: recurrenceEnd)]
+        let daysOfTheMonth = recurrenceRuleArguments![daysOfTheMonthArgument] as? [NSNumber]
+        //var daysOfTheMonthNum: [NSNumber]? = nil
+        
+        return [EKRecurrenceRule(recurrenceWith: namedFrequency, interval: recurrenceInterval, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: recurrenceRuleArguments![daysOfTheMonthArgument] as? [NSNumber], monthsOfTheYear: nil, weeksOfTheYear: nil, daysOfTheYear: nil, setPositions: nil, end: recurrenceEnd)]
     }
     
     private func createOrUpdateEvent(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -34,6 +34,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let endDate: Int64?
         let daysOfTheWeek: [Int]?
         let daysOfTheMonth: [Int]?
+        let monthsOfTheYear: [Int]?
     }
     
     struct Attendee: Codable {
@@ -76,6 +77,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
     let intervalArgument = "interval"
     let daysOfTheWeekArgument = "daysOfTheWeek"
     let daysOfTheMonthArgument = "daysOfTheMonth"
+    let monthsOfTheYearArgument = "monthsOfTheYear"
     let validFrequencyTypes = [EKRecurrenceFrequency.daily, EKRecurrenceFrequency.weekly, EKRecurrenceFrequency.monthly, EKRecurrenceFrequency.yearly]
 
     
@@ -244,7 +246,16 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                     daysOfTheMonth!.append(dayOfTheMonth.intValue)
                 }
             }
-            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: daysOfTheMonth)
+            
+            var monthsOfTheYear: [Int]? = nil
+            if(ekRecurrenceRule.monthsOfTheYear != nil) {
+                monthsOfTheYear = []
+                for monthOfTheYear in ekRecurrenceRule.monthsOfTheYear! {
+                    monthsOfTheYear!.append(monthOfTheYear.intValue)
+                }
+            }
+            
+            recurrenceRule = RecurrenceRule(recurrenceFrequency: frequency, totalOccurrences: totalOccurrences, interval: ekRecurrenceRule.interval, endDate: endDate, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: daysOfTheMonth, monthsOfTheYear: monthsOfTheYear)
         }
         return recurrenceRule
     }
@@ -283,10 +294,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
             }
         }
         
-        let daysOfTheMonth = recurrenceRuleArguments![daysOfTheMonthArgument] as? [NSNumber]
-        //var daysOfTheMonthNum: [NSNumber]? = nil
-        
-        return [EKRecurrenceRule(recurrenceWith: namedFrequency, interval: recurrenceInterval, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: recurrenceRuleArguments![daysOfTheMonthArgument] as? [NSNumber], monthsOfTheYear: nil, weeksOfTheYear: nil, daysOfTheYear: nil, setPositions: nil, end: recurrenceEnd)]
+        return [EKRecurrenceRule(recurrenceWith: namedFrequency, interval: recurrenceInterval, daysOfTheWeek: daysOfTheWeek, daysOfTheMonth: recurrenceRuleArguments![daysOfTheMonthArgument] as? [NSNumber], monthsOfTheYear: recurrenceRuleArguments![monthsOfTheYearArgument] as? [NSNumber], weeksOfTheYear: nil, daysOfTheYear: nil, setPositions: nil, end: recurrenceEnd)]
     }
     
     private func createOrUpdateEvent(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -8,11 +8,8 @@ extension Date {
 
 extension EKParticipant {
     var emailAddress: String? {
-        if(self.url.scheme == nil) {
-            return nil
-        }
-        
-        return url.absoluteString.replacingOccurrences(of: self.url.scheme! + ":", with: "") }
+        return self.value(forKey: "emailAddress") as? String
+    }
 }
 
 public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -345,30 +345,6 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
             ekEvent!.recurrenceRules = createEKRecurrenceRules(arguments)
             ekEvent!.location = location
             
-            let recurrenceRuleArguments = arguments[recurrenceRuleArgument] as? Dictionary<String, AnyObject>
-            if (recurrenceRuleArguments != nil) {
-                let recurrenceFrequencyIndex = recurrenceRuleArguments![recurrenceFrequencyArgument] as? NSInteger
-                let totalOccurrences = recurrenceRuleArguments![totalOccurrencesArgument] as? NSInteger
-                let interval = recurrenceRuleArguments![intervalArgument] as? NSInteger
-                var recurrenceInterval = 1
-                let endDate = recurrenceRuleArguments![endDateArgument] as? NSNumber
-                let namedFrequency = validFrequencyTypes[recurrenceFrequencyIndex!]
-                
-                var recurrenceEnd:EKRecurrenceEnd?
-                if(endDate != nil) {
-                    recurrenceEnd = EKRecurrenceEnd(end: Date.init(timeIntervalSince1970: endDate!.doubleValue / 1000))
-                } else if(totalOccurrences != nil && totalOccurrences! > 0) {
-                    recurrenceEnd = EKRecurrenceEnd(occurrenceCount: totalOccurrences!)
-                }
-                
-                if(interval != nil && interval! > 1) {
-                    recurrenceInterval = interval!
-                }
-                
-                ekEvent!.recurrenceRules = [EKRecurrenceRule(recurrenceWith: namedFrequency, interval: recurrenceInterval, end: recurrenceEnd)]
-            } else {
-                ekEvent!.recurrenceRules = nil
-            }
             do {
                 try self.eventStore.save(ekEvent!, span: .futureEvents)
                 result(ekEvent!.eventIdentifier)

--- a/device_calendar/lib/device_calendar.dart
+++ b/device_calendar/lib/device_calendar.dart
@@ -1,5 +1,6 @@
 library device_calendar;
 
+export 'src/common/day_of_week.dart';
 export 'src/common/recurrence_frequency.dart';
 export 'src/models/attendee.dart';
 export 'src/models/calendar.dart';

--- a/device_calendar/lib/device_calendar.dart
+++ b/device_calendar/lib/device_calendar.dart
@@ -5,6 +5,7 @@ export 'src/common/recurrence_frequency.dart';
 export 'src/models/attendee.dart';
 export 'src/models/calendar.dart';
 export 'src/models/result.dart';
+export 'src/models/reminder.dart';
 export 'src/models/event.dart';
 export 'src/models/retrieve_events_params.dart';
 export 'src/models/recurrence_rule.dart';

--- a/device_calendar/lib/device_calendar.dart
+++ b/device_calendar/lib/device_calendar.dart
@@ -8,4 +8,7 @@ export 'src/models/result.dart';
 export 'src/models/event.dart';
 export 'src/models/retrieve_events_params.dart';
 export 'src/models/recurrence_rule.dart';
+export 'src/models/platform_specifics/ios/attendee_details.dart';
+export 'src/models/platform_specifics/ios/role.dart';
+export 'src/models/platform_specifics/android/attendee_details.dart';
 export 'src/device_calendar.dart';

--- a/device_calendar/lib/src/common/day_of_week.dart
+++ b/device_calendar/lib/src/common/day_of_week.dart
@@ -1,0 +1,1 @@
+enum DayOfWeek { Sunday, Monday, Tuesday, Wednesday, Thursday, Friday }

--- a/device_calendar/lib/src/common/day_of_week.dart
+++ b/device_calendar/lib/src/common/day_of_week.dart
@@ -1,1 +1,1 @@
-enum DayOfWeek { Sunday, Monday, Tuesday, Wednesday, Thursday, Friday }
+enum DayOfTheWeek { Sunday, Monday, Tuesday, Wednesday, Thursday, Friday }

--- a/device_calendar/lib/src/common/day_of_week.dart
+++ b/device_calendar/lib/src/common/day_of_week.dart
@@ -1,1 +1,9 @@
-enum DayOfTheWeek { Sunday, Monday, Tuesday, Wednesday, Thursday, Friday }
+enum DayOfTheWeek {
+  Sunday,
+  Monday,
+  Tuesday,
+  Wednesday,
+  Thursday,
+  Friday,
+  Saturday
+}

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -15,15 +15,14 @@ class DeviceCalendarPlugin {
   static const MethodChannel channel =
       const MethodChannel('plugins.builttoroam.com/device_calendar');
 
-  static final DeviceCalendarPlugin _instance =
-      DeviceCalendarPlugin._createInstance();
+  static final DeviceCalendarPlugin _instance = DeviceCalendarPlugin.private();
 
   factory DeviceCalendarPlugin() {
     return _instance;
   }
 
   @visibleForTesting
-  DeviceCalendarPlugin._createInstance();
+  DeviceCalendarPlugin.private();
 
   /// Requests permissions to modify the calendars on the device
   ///

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -94,7 +94,7 @@ class DeviceCalendarPlugin {
           "[${ErrorCodes.invalidArguments}] ${ErrorMessages.invalidMissingCalendarId}");
     }
 
-    // TODO: Extend capability to handle null start or null end (eg all events after a certain date (null end date) or all events prior to a certain date (null start date))
+    // TODO: Extend capability to handle null start or null end (e.g. all events after a certain date (null end date) or all events prior to a certain date (null start date))
     if ((retrieveEventsParams?.eventIds?.isEmpty ?? true) &&
         ((retrieveEventsParams?.startDate == null ||
                 retrieveEventsParams?.endDate == null) ||

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -180,7 +180,7 @@ class DeviceCalendarPlugin {
         'eventDescription': event.description,
         'eventStartDate': event.start.millisecondsSinceEpoch,
         'eventEndDate': event.end.millisecondsSinceEpoch,
-        'recurrenceRule': event.recurrenceRule?.toJson()
+        'recurrenceRule': event.recurrenceRule?.toJson(),
       });
     } catch (e) {
       _parsePlatformExceptionAndUpdateResult<String>(e, res);

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -163,7 +163,6 @@ class DeviceCalendarPlugin {
     final res = new Result<String>();
 
     if ((event?.calendarId?.isEmpty ?? true) ||
-        (event?.title?.isEmpty ?? true) ||
         event.start == null ||
         event.end == null ||
         event.start.isAfter(event.end)) {

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -67,7 +67,7 @@ class DeviceCalendarPlugin {
 
       res.data = json.decode(calendarsJson).map<Calendar>((decodedCalendar) {
         return Calendar.fromJson(decodedCalendar);
-      }).toList();
+      }).toList(growable: false);
     } catch (e) {
       _parsePlatformExceptionAndUpdateResult<List<Calendar>>(e, res);
     }
@@ -117,7 +117,7 @@ class DeviceCalendarPlugin {
 
         res.data = json.decode(eventsJson).map<Event>((decodedEvent) {
           return Event.fromJson(decodedEvent);
-        }).toList();
+        }).toList(growable: false);
       } catch (e) {
         _parsePlatformExceptionAndUpdateResult<List<Event>>(e, res);
       }

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -183,6 +183,7 @@ class DeviceCalendarPlugin {
         'eventLocation': event.location,
         'recurrenceRule': event.recurrenceRule?.toJson(),
         'attendees': event.attendees?.map((a) => a.toJson())?.toList(),
+        'reminders': event.reminders?.map((r) => r.toJson())?.toList()
       });
     } catch (e) {
       _parsePlatformExceptionAndUpdateResult<String>(e, res);

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
@@ -59,17 +60,19 @@ class DeviceCalendarPlugin {
   /// Retrieves all of the device defined calendars
   ///
   /// Returns a [Result] containing a list of device [Calendar]
-  Future<Result<List<Calendar>>> retrieveCalendars() async {
-    final res = Result<List<Calendar>>();
+  Future<Result<UnmodifiableListView<Calendar>>> retrieveCalendars() async {
+    final res = Result<UnmodifiableListView<Calendar>>();
 
     try {
       var calendarsJson = await channel.invokeMethod('retrieveCalendars');
 
-      res.data = json.decode(calendarsJson).map<Calendar>((decodedCalendar) {
+      res.data = UnmodifiableListView(
+          json.decode(calendarsJson).map<Calendar>((decodedCalendar) {
         return Calendar.fromJson(decodedCalendar);
-      }).toList(growable: false);
+      }));
     } catch (e) {
-      _parsePlatformExceptionAndUpdateResult<List<Calendar>>(e, res);
+      _parsePlatformExceptionAndUpdateResult<UnmodifiableListView<Calendar>>(
+          e, res);
     }
 
     return res;
@@ -84,9 +87,9 @@ class DeviceCalendarPlugin {
   ///
   /// Returns a [Result] containing a list [Event], that fall
   /// into the specified parameters
-  Future<Result<List<Event>>> retrieveEvents(
+  Future<Result<UnmodifiableListView<Event>>> retrieveEvents(
       String calendarId, RetrieveEventsParams retrieveEventsParams) async {
-    final res = Result<List<Event>>();
+    final res = Result<UnmodifiableListView<Event>>();
 
     if ((calendarId?.isEmpty ?? true)) {
       res.errorMessages.add(
@@ -115,11 +118,13 @@ class DeviceCalendarPlugin {
           'eventIds': retrieveEventsParams.eventIds
         });
 
-        res.data = json.decode(eventsJson).map<Event>((decodedEvent) {
+        res.data = UnmodifiableListView(
+            json.decode(eventsJson).map<Event>((decodedEvent) {
           return Event.fromJson(decodedEvent);
-        }).toList(growable: false);
+        }));
       } catch (e) {
-        _parsePlatformExceptionAndUpdateResult<List<Event>>(e, res);
+        _parsePlatformExceptionAndUpdateResult<UnmodifiableListView<Event>>(
+            e, res);
       }
     }
 

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -16,7 +16,7 @@ class DeviceCalendarPlugin {
       const MethodChannel('plugins.builttoroam.com/device_calendar');
 
   static final DeviceCalendarPlugin _instance =
-      new DeviceCalendarPlugin._createInstance();
+      DeviceCalendarPlugin._createInstance();
 
   factory DeviceCalendarPlugin() {
     return _instance;
@@ -30,7 +30,7 @@ class DeviceCalendarPlugin {
   /// Returns a [Result] indicating if calendar READ and WRITE permissions
   /// have (true) or have not (false) been granted
   Future<Result<bool>> requestPermissions() async {
-    final res = new Result<bool>();
+    final res = Result<bool>();
 
     try {
       res.data = await channel.invokeMethod('requestPermissions');
@@ -46,7 +46,7 @@ class DeviceCalendarPlugin {
   /// Returns a [Result] indicating if calendar READ and WRITE permissions
   /// have (true) or have not (false) been granted
   Future<Result<bool>> hasPermissions() async {
-    final res = new Result<bool>();
+    final res = Result<bool>();
 
     try {
       res.data = await channel.invokeMethod('hasPermissions');
@@ -61,13 +61,13 @@ class DeviceCalendarPlugin {
   ///
   /// Returns a [Result] containing a list of device [Calendar]
   Future<Result<List<Calendar>>> retrieveCalendars() async {
-    final res = new Result<List<Calendar>>();
+    final res = Result<List<Calendar>>();
 
     try {
       var calendarsJson = await channel.invokeMethod('retrieveCalendars');
 
       res.data = json.decode(calendarsJson).map<Calendar>((decodedCalendar) {
-        return new Calendar.fromJson(decodedCalendar);
+        return Calendar.fromJson(decodedCalendar);
       }).toList();
     } catch (e) {
       _parsePlatformExceptionAndUpdateResult<List<Calendar>>(e, res);
@@ -87,7 +87,7 @@ class DeviceCalendarPlugin {
   /// into the specified parameters
   Future<Result<List<Event>>> retrieveEvents(
       String calendarId, RetrieveEventsParams retrieveEventsParams) async {
-    final res = new Result<List<Event>>();
+    final res = Result<List<Event>>();
 
     if ((calendarId?.isEmpty ?? true)) {
       res.errorMessages.add(
@@ -117,7 +117,7 @@ class DeviceCalendarPlugin {
         });
 
         res.data = json.decode(eventsJson).map<Event>((decodedEvent) {
-          return new Event.fromJson(decodedEvent);
+          return Event.fromJson(decodedEvent);
         }).toList();
       } catch (e) {
         _parsePlatformExceptionAndUpdateResult<List<Event>>(e, res);
@@ -134,7 +134,7 @@ class DeviceCalendarPlugin {
   ///
   /// Returns a [Result] indicating if the event has (true) or has not (false) been deleted from the calendar
   Future<Result<bool>> deleteEvent(String calendarId, String eventId) async {
-    final res = new Result<bool>();
+    final res = Result<bool>();
 
     if ((calendarId?.isEmpty ?? true) || (eventId?.isEmpty ?? true)) {
       res.errorMessages.add(
@@ -160,7 +160,7 @@ class DeviceCalendarPlugin {
   ///
   /// Returns a [Result] with the newly created or updated [Event.eventId]
   Future<Result<String>> createOrUpdateEvent(Event event) async {
-    final res = new Result<String>();
+    final res = Result<String>();
 
     if ((event?.calendarId?.isEmpty ?? true) ||
         event.start == null ||

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -181,7 +181,8 @@ class DeviceCalendarPlugin {
         'eventStartDate': event.start.millisecondsSinceEpoch,
         'eventEndDate': event.end.millisecondsSinceEpoch,
         'eventLocation': event.location,
-        'recurrenceRule': event.recurrenceRule?.toJson()
+        'recurrenceRule': event.recurrenceRule?.toJson(),
+        'attendees': event.attendees?.map((a) => a.toJson())?.toList(),
       });
     } catch (e) {
       _parsePlatformExceptionAndUpdateResult<String>(e, res);

--- a/device_calendar/lib/src/models/attendee.dart
+++ b/device_calendar/lib/src/models/attendee.dart
@@ -1,4 +1,4 @@
-import 'package:platform/platform.dart';
+import 'dart:io' show Platform;
 
 import '../common/error_messages.dart';
 import 'platform_specifics/android/attendee_details.dart';
@@ -29,12 +29,11 @@ class Attendee {
 
     name = json['name'];
     emailAddress = json['emailAddress'];
-    final platform = LocalPlatform();
-    if (platform.isAndroid) {
+    if (Platform.isAndroid) {
       androidAttendeeDetails = AndroidAttendeeDetails.fromJson(json);
     }
 
-    if (platform.isIOS) {
+    if (Platform.isIOS) {
       iosAttendeeDetails = IosAttendeeDetails.fromJson(json);
     }
   }

--- a/device_calendar/lib/src/models/attendee.dart
+++ b/device_calendar/lib/src/models/attendee.dart
@@ -1,4 +1,8 @@
+import 'package:platform/platform.dart';
+
 import '../common/error_messages.dart';
+import 'platform_specifics/android/attendee_details.dart';
+import 'platform_specifics/ios/attendee_details.dart';
 
 /// A person attending an event
 class Attendee {
@@ -7,6 +11,14 @@ class Attendee {
 
   ///  The email address of the attendee
   String emailAddress;
+
+  /// Details about the attendee that are specific to iOS.
+  /// When reading details for an existing event, this will only be populated on iOS devices.
+  IosAttendeeDetails iosAttendeeDetails;
+
+  /// Details about the attendee that are specific to Android.
+  /// When reading details for an existing event, this will only be populated on Android devices.
+  AndroidAttendeeDetails androidAttendeeDetails;
 
   Attendee({this.name, this.emailAddress});
 
@@ -17,11 +29,19 @@ class Attendee {
 
     name = json['name'];
     emailAddress = json['emailAddress'];
+    final platform = LocalPlatform();
+    if (platform.isAndroid) {
+      androidAttendeeDetails = AndroidAttendeeDetails.fromJson(json);
+    }
+
+    if (platform.isIOS) {
+      iosAttendeeDetails = IosAttendeeDetails.fromJson(json);
+    }
   }
 
-  Map<String, dynamic> toJson() {
+  /*Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = Map<String, dynamic>();
     data['name'] = this.name;
     return data;
-  }
+  }*/
 }

--- a/device_calendar/lib/src/models/attendee.dart
+++ b/device_calendar/lib/src/models/attendee.dart
@@ -9,14 +9,14 @@ class Attendee {
 
   Attendee.fromJson(Map<String, dynamic> json) {
     if (json == null) {
-      throw new ArgumentError(ErrorMessages.fromJsonMapIsNull);
+      throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
 
     name = json['name'];
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
+    final Map<String, dynamic> data = Map<String, dynamic>();
     data['name'] = this.name;
     return data;
   }

--- a/device_calendar/lib/src/models/attendee.dart
+++ b/device_calendar/lib/src/models/attendee.dart
@@ -6,13 +6,13 @@ import 'platform_specifics/ios/attendee_details.dart';
 
 /// A person attending an event
 class Attendee {
-  /// The name of the attendee
+  /// The name of the attendee. Currently has no effect when saving attendees on iOS.
   String name;
 
   ///  The email address of the attendee
   String emailAddress;
 
-  /// Details about the attendee that are specific to iOS.
+  /// Details about the attendee that are specific to iOS. Currently has no effect when saving attendees on iOS.
   /// When reading details for an existing event, this will only be populated on iOS devices.
   IosAttendeeDetails iosAttendeeDetails;
 
@@ -20,7 +20,11 @@ class Attendee {
   /// When reading details for an existing event, this will only be populated on Android devices.
   AndroidAttendeeDetails androidAttendeeDetails;
 
-  Attendee({this.name, this.emailAddress});
+  Attendee(
+      {this.name,
+      this.emailAddress,
+      this.iosAttendeeDetails,
+      this.androidAttendeeDetails});
 
   Attendee.fromJson(Map<String, dynamic> json) {
     if (json == null) {
@@ -38,9 +42,16 @@ class Attendee {
     }
   }
 
-  /*Map<String, dynamic> toJson() {
+  Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = Map<String, dynamic>();
-    data['name'] = this.name;
+    data['name'] = name;
+    data['emailAddress'] = emailAddress;
+    if (Platform.isIOS && iosAttendeeDetails != null) {
+      data.addEntries(iosAttendeeDetails.toJson().entries);
+    }
+    if (Platform.isAndroid && androidAttendeeDetails != null) {
+      data.addEntries(androidAttendeeDetails.toJson().entries);
+    }
     return data;
-  }*/
+  }
 }

--- a/device_calendar/lib/src/models/attendee.dart
+++ b/device_calendar/lib/src/models/attendee.dart
@@ -5,7 +5,10 @@ class Attendee {
   /// The name of the attendee
   String name;
 
-  Attendee(this.name);
+  ///  The email address of the attendee
+  String emailAddress;
+
+  Attendee({this.name, this.emailAddress});
 
   Attendee.fromJson(Map<String, dynamic> json) {
     if (json == null) {
@@ -13,6 +16,7 @@ class Attendee {
     }
 
     name = json['name'];
+    emailAddress = json['emailAddress'];
   }
 
   Map<String, dynamic> toJson() {

--- a/device_calendar/lib/src/models/calendar.dart
+++ b/device_calendar/lib/src/models/calendar.dart
@@ -18,7 +18,7 @@ class Calendar {
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
+    final Map<String, dynamic> data = Map<String, dynamic>();
     data['id'] = this.id;
     data['name'] = this.name;
     data['isReadOnly'] = this.isReadOnly;

--- a/device_calendar/lib/src/models/event.dart
+++ b/device_calendar/lib/src/models/event.dart
@@ -87,14 +87,14 @@ class Event {
     data['end'] = this.end.millisecondsSinceEpoch;
     data['allDay'] = this.allDay;
     data['location'] = this.location;
-    if (attendees != null) {
+    /*if (attendees != null) {
       List<Map<String, dynamic>> attendeesJson = List();
       for (var attendee in attendees) {
         var attendeeJson = attendee.toJson();
         attendeesJson.add(attendeeJson);
       }
       data['attendees'] = attendeesJson;
-    }
+    }*/
     if (recurrenceRule != null) {
       data['recurrenceRule'] = recurrenceRule.toJson();
     }

--- a/device_calendar/lib/src/models/event.dart
+++ b/device_calendar/lib/src/models/event.dart
@@ -1,3 +1,4 @@
+import '../../device_calendar.dart';
 import '../common/error_messages.dart';
 import 'attendee.dart';
 import 'recurrence_rule.dart';
@@ -39,6 +40,8 @@ class Event {
   /// The recurrence rule for this event
   RecurrenceRule recurrenceRule;
 
+  List<Reminder> reminders;
+
   Event(this.calendarId,
       {this.eventId,
       this.title,
@@ -78,9 +81,15 @@ class Event {
     if (json['organizer'] != null) {
       _organizer = Attendee.fromJson(json['organizer']);
     }
+    if (json['reminders'] != null) {
+      reminders = json['reminders'].map<Reminder>((decodedReminder) {
+        return Reminder.fromJson(decodedReminder);
+      }).toList();
+    }
   }
 
-  Map<String, dynamic> toJson() {
+  // TODO: look at using this method
+  /* Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = Map<String, dynamic>();
     data['eventId'] = eventId;
     data['calendarId'] = calendarId;
@@ -96,6 +105,9 @@ class Event {
     if (recurrenceRule != null) {
       data['recurrenceRule'] = recurrenceRule.toJson();
     }
+    if (reminders != null) {
+      data['reminders'] = reminders.map((r) => r.toJson()).toList();
+    }
     return data;
-  }
+  }*/
 }

--- a/device_calendar/lib/src/models/event.dart
+++ b/device_calendar/lib/src/models/event.dart
@@ -4,6 +4,8 @@ import 'recurrence_rule.dart';
 
 /// An event associated with a calendar
 class Event {
+  Attendee _organizer;
+
   /// The unique identifier for this event
   String eventId;
 
@@ -31,8 +33,8 @@ class Event {
   /// A list of attendees for this event
   List<Attendee> attendees;
 
-  /// The organizer of this event
-  Attendee organizer;
+  /// The organizer of this event. This property is read-only
+  Attendee get organizer => _organizer;
 
   /// The recurrence rule for this event
   RecurrenceRule recurrenceRule;
@@ -74,7 +76,7 @@ class Event {
       recurrenceRule = RecurrenceRule.fromJson(json['recurrenceRule']);
     }
     if (json['organizer'] != null) {
-      organizer = Attendee.fromJson(json['organizer']);
+      _organizer = Attendee.fromJson(json['organizer']);
     }
   }
 
@@ -89,7 +91,6 @@ class Event {
     data['allDay'] = allDay;
     data['location'] = location;
     if (attendees != null) {
-      print('have attendees');
       data['attendees'] = attendees.map((a) => a.toJson()).toList();
     }
     if (recurrenceRule != null) {

--- a/device_calendar/lib/src/models/event.dart
+++ b/device_calendar/lib/src/models/event.dart
@@ -31,6 +31,9 @@ class Event {
   /// A list of attendees for this event
   List<Attendee> attendees;
 
+  /// The organizer of this event
+  Attendee organizer;
+
   /// The recurrence rule for this event
   RecurrenceRule recurrenceRule;
 
@@ -68,6 +71,9 @@ class Event {
     }
     if (json['recurrenceRule'] != null) {
       recurrenceRule = RecurrenceRule.fromJson(json['recurrenceRule']);
+    }
+    if (json['organizer'] != null) {
+      organizer = Attendee.fromJson(json['organizer']);
     }
   }
 

--- a/device_calendar/lib/src/models/event.dart
+++ b/device_calendar/lib/src/models/event.dart
@@ -44,7 +44,7 @@ class Event {
 
   Event.fromJson(Map<String, dynamic> json) {
     if (json == null) {
-      throw new ArgumentError(ErrorMessages.fromJsonMapIsNull);
+      throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
 
     eventId = json['eventId'];
@@ -53,18 +53,17 @@ class Event {
     description = json['description'];
     int startMillisecondsSinceEpoch = json['start'];
     if (startMillisecondsSinceEpoch != null) {
-      start =
-          new DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch);
+      start = DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch);
     }
     int endMillisecondsSinceEpoch = json['end'];
     if (endMillisecondsSinceEpoch != null) {
-      end = new DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch);
+      end = DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch);
     }
     allDay = json['allDay'];
     location = json['location'];
     if (json['attendees'] != null) {
       attendees = json['attendees'].map<Attendee>((decodedAttendee) {
-        return new Attendee.fromJson(decodedAttendee);
+        return Attendee.fromJson(decodedAttendee);
       }).toList();
     }
     if (json['recurrenceRule'] != null) {
@@ -73,7 +72,7 @@ class Event {
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
+    final Map<String, dynamic> data = Map<String, dynamic>();
     data['eventId'] = this.eventId;
     data['calendarId'] = this.calendarId;
     data['title'] = this.title;
@@ -83,7 +82,7 @@ class Event {
     data['allDay'] = this.allDay;
     data['location'] = this.location;
     if (attendees != null) {
-      List<Map<String, dynamic>> attendeesJson = new List();
+      List<Map<String, dynamic>> attendeesJson = List();
       for (var attendee in attendees) {
         var attendeeJson = attendee.toJson();
         attendeesJson.add(attendeeJson);

--- a/device_calendar/lib/src/models/event.dart
+++ b/device_calendar/lib/src/models/event.dart
@@ -43,6 +43,7 @@ class Event {
       this.start,
       this.end,
       this.description,
+      this.attendees,
       this.recurrenceRule});
 
   Event.fromJson(Map<String, dynamic> json) {
@@ -79,22 +80,18 @@ class Event {
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = Map<String, dynamic>();
-    data['eventId'] = this.eventId;
-    data['calendarId'] = this.calendarId;
-    data['title'] = this.title;
-    data['description'] = this.description;
-    data['start'] = this.start.millisecondsSinceEpoch;
-    data['end'] = this.end.millisecondsSinceEpoch;
-    data['allDay'] = this.allDay;
-    data['location'] = this.location;
-    /*if (attendees != null) {
-      List<Map<String, dynamic>> attendeesJson = List();
-      for (var attendee in attendees) {
-        var attendeeJson = attendee.toJson();
-        attendeesJson.add(attendeeJson);
-      }
-      data['attendees'] = attendeesJson;
-    }*/
+    data['eventId'] = eventId;
+    data['calendarId'] = calendarId;
+    data['title'] = title;
+    data['description'] = description;
+    data['start'] = start.millisecondsSinceEpoch;
+    data['end'] = end.millisecondsSinceEpoch;
+    data['allDay'] = allDay;
+    data['location'] = location;
+    if (attendees != null) {
+      print('have attendees');
+      data['attendees'] = attendees.map((a) => a.toJson()).toList();
+    }
     if (recurrenceRule != null) {
       data['recurrenceRule'] = recurrenceRule.toJson();
     }

--- a/device_calendar/lib/src/models/platform_specifics/android/attendance_status.dart
+++ b/device_calendar/lib/src/models/platform_specifics/android/attendance_status.dart
@@ -1,0 +1,1 @@
+enum AndroidAttendanceStatus { None, Accepted, Declined, Invited, Tentative }

--- a/device_calendar/lib/src/models/platform_specifics/android/attendee_details.dart
+++ b/device_calendar/lib/src/models/platform_specifics/android/attendee_details.dart
@@ -1,4 +1,5 @@
 import 'package:device_calendar/src/models/platform_specifics/android/attendance_status.dart';
+import 'package:flutter/foundation.dart';
 
 import '../../../common/error_messages.dart';
 
@@ -10,6 +11,8 @@ class AndroidAttendeeDetails {
 
   /// The attendee's status for the event. This is read-only
   AndroidAttendanceStatus get attendanceStatus => _attendanceStatus;
+
+  AndroidAttendeeDetails({@required this.isRequired});
 
   AndroidAttendeeDetails.fromJson(Map<String, dynamic> json) {
     if (json == null) {

--- a/device_calendar/lib/src/models/platform_specifics/android/attendee_details.dart
+++ b/device_calendar/lib/src/models/platform_specifics/android/attendee_details.dart
@@ -1,13 +1,21 @@
+import 'package:device_calendar/src/models/platform_specifics/android/attendance_status.dart';
+
 import '../../../common/error_messages.dart';
 
 class AndroidAttendeeDetails {
   /// Indicates if the attendee is required for this event
   bool isRequired;
 
+  AndroidAttendanceStatus attendanceStatus;
+
   AndroidAttendeeDetails.fromJson(Map<String, dynamic> json) {
     if (json == null) {
       throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
     isRequired = json['isRequired'];
+    if (json['attendanceStatus'] != null && json['attendanceStatus'] is int) {
+      attendanceStatus =
+          AndroidAttendanceStatus.values[json['attendanceStatus']];
+    }
   }
 }

--- a/device_calendar/lib/src/models/platform_specifics/android/attendee_details.dart
+++ b/device_calendar/lib/src/models/platform_specifics/android/attendee_details.dart
@@ -1,0 +1,13 @@
+import '../../../common/error_messages.dart';
+
+class AndroidAttendeeDetails {
+  /// Indicates if the attendee is required for this event
+  bool isRequired;
+
+  AndroidAttendeeDetails.fromJson(Map<String, dynamic> json) {
+    if (json == null) {
+      throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
+    }
+    isRequired = json['isRequired'];
+  }
+}

--- a/device_calendar/lib/src/models/platform_specifics/android/attendee_details.dart
+++ b/device_calendar/lib/src/models/platform_specifics/android/attendee_details.dart
@@ -3,10 +3,13 @@ import 'package:device_calendar/src/models/platform_specifics/android/attendance
 import '../../../common/error_messages.dart';
 
 class AndroidAttendeeDetails {
+  AndroidAttendanceStatus _attendanceStatus;
+
   /// Indicates if the attendee is required for this event
   bool isRequired;
 
-  AndroidAttendanceStatus attendanceStatus;
+  /// The attendee's status for the event. This is read-only
+  AndroidAttendanceStatus get attendanceStatus => _attendanceStatus;
 
   AndroidAttendeeDetails.fromJson(Map<String, dynamic> json) {
     if (json == null) {
@@ -14,8 +17,12 @@ class AndroidAttendeeDetails {
     }
     isRequired = json['isRequired'];
     if (json['attendanceStatus'] != null && json['attendanceStatus'] is int) {
-      attendanceStatus =
+      _attendanceStatus =
           AndroidAttendanceStatus.values[json['attendanceStatus']];
     }
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{'isRequired': isRequired};
   }
 }

--- a/device_calendar/lib/src/models/platform_specifics/ios/attendance_status.dart
+++ b/device_calendar/lib/src/models/platform_specifics/ios/attendance_status.dart
@@ -1,0 +1,10 @@
+enum IosAttendanceStatus {
+  Unknown,
+  Pending,
+  Accepted,
+  Declined,
+  Tentative,
+  Delegated,
+  Completed,
+  InProcess
+}

--- a/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
+++ b/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
@@ -1,3 +1,5 @@
+import 'package:device_calendar/src/models/platform_specifics/ios/attendance_status.dart';
+
 import '../../../common/error_messages.dart';
 import 'role.dart';
 
@@ -5,12 +7,17 @@ class IosAttendeeDetails {
   // The attendee's role at an event
   Role role;
 
+  IosAttendanceStatus attendanceStatus;
+
   IosAttendeeDetails.fromJson(Map<String, dynamic> json) {
     if (json == null) {
       throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
     if (json['role'] != null && json['role'] is int) {
       role = Role.values[json['role']];
+    }
+    if (json['attendanceStatus'] != null && json['attendanceStatus'] is int) {
+      attendanceStatus = IosAttendanceStatus.values[json['attendanceStatus']];
     }
   }
 }

--- a/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
+++ b/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import '../../../common/error_messages.dart';
 import 'attendance_status.dart';
 import 'role.dart';

--- a/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
+++ b/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
@@ -1,6 +1,7 @@
-import 'package:device_calendar/src/models/platform_specifics/ios/attendance_status.dart';
+import 'package:flutter/foundation.dart';
 
 import '../../../common/error_messages.dart';
+import 'attendance_status.dart';
 import 'role.dart';
 
 class IosAttendeeDetails {
@@ -11,7 +12,7 @@ class IosAttendeeDetails {
   /// The attendee's status for the event. This is read-only
   IosAttendanceStatus get attendanceStatus => _attendanceStatus;
 
-  IosAttendeeDetails(this.role);
+  IosAttendeeDetails({this.role});
 
   IosAttendeeDetails.fromJson(Map<String, dynamic> json) {
     if (json == null) {

--- a/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
+++ b/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
@@ -4,10 +4,14 @@ import '../../../common/error_messages.dart';
 import 'role.dart';
 
 class IosAttendeeDetails {
+  IosAttendanceStatus _attendanceStatus;
   // The attendee's role at an event
   Role role;
 
-  IosAttendanceStatus attendanceStatus;
+  /// The attendee's status for the event. This is read-only
+  IosAttendanceStatus get attendanceStatus => _attendanceStatus;
+
+  IosAttendeeDetails(this.role);
 
   IosAttendeeDetails.fromJson(Map<String, dynamic> json) {
     if (json == null) {
@@ -17,7 +21,13 @@ class IosAttendeeDetails {
       role = Role.values[json['role']];
     }
     if (json['attendanceStatus'] != null && json['attendanceStatus'] is int) {
-      attendanceStatus = IosAttendanceStatus.values[json['attendanceStatus']];
+      _attendanceStatus = IosAttendanceStatus.values[json['attendanceStatus']];
     }
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'role': role?.index,
+    };
   }
 }

--- a/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
+++ b/device_calendar/lib/src/models/platform_specifics/ios/attendee_details.dart
@@ -1,0 +1,16 @@
+import '../../../common/error_messages.dart';
+import 'role.dart';
+
+class IosAttendeeDetails {
+  // The attendee's role at an event
+  Role role;
+
+  IosAttendeeDetails.fromJson(Map<String, dynamic> json) {
+    if (json == null) {
+      throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
+    }
+    if (json['role'] != null && json['role'] is int) {
+      role = Role.values[json['role']];
+    }
+  }
+}

--- a/device_calendar/lib/src/models/platform_specifics/ios/role.dart
+++ b/device_calendar/lib/src/models/platform_specifics/ios/role.dart
@@ -1,0 +1,3 @@
+/// The available roles of an attendee at an event.
+/// This is iOS specific and based on the values from https://developer.apple.com/documentation/eventkit/ekparticipantrole
+enum Role { Unknown, Required, Optional, Chair, NonParticipant }

--- a/device_calendar/lib/src/models/recurrence_rule.dart
+++ b/device_calendar/lib/src/models/recurrence_rule.dart
@@ -50,11 +50,13 @@ class RecurrenceRule {
       endDate =
           DateTime.fromMillisecondsSinceEpoch(endDateMillisecondsSinceEpoch);
     }
-    /*List<int> daysOfWeekIndices = json[_daysOfWeekKey];
-    if (daysOfWeekIndices != null) {
-      daysOfWeek =
-          daysOfWeekIndices.map((index) => DayOfWeek.values[index]).toList();
-    }*/
+    List<Object> daysOfWeekIndices = json[_daysOfWeekKey];
+    if (daysOfWeekIndices != null && daysOfWeekIndices is! List<int>) {
+      daysOfWeek = daysOfWeekIndices
+          .cast<int>()
+          .map((index) => DayOfWeek.values[index])
+          .toList();
+    }
   }
 
   Map<String, dynamic> toJson() {

--- a/device_calendar/lib/src/models/recurrence_rule.dart
+++ b/device_calendar/lib/src/models/recurrence_rule.dart
@@ -16,7 +16,7 @@ class RecurrenceRule {
   RecurrenceFrequency recurrenceFrequency;
 
   /// The days of the week that this event occurs on. Only applicable to rules with a weekly, monthly or yearly frequency
-  List<DayOfWeek> daysOfTheWeek;
+  List<DayOfTheWeek> daysOfTheWeek;
 
   /// The days of the month that this event occurs on. Only applicable to recurrence rules with a monthly frequency
   List<int> daysOfTheMonth;
@@ -39,7 +39,9 @@ class RecurrenceRule {
         assert(
             (daysOfTheWeek?.isEmpty ?? true) ||
                 ((daysOfTheWeek?.isNotEmpty ?? false) &&
-                    (recurrenceFrequency == RecurrenceFrequency.Daily)),
+                    (recurrenceFrequency == RecurrenceFrequency.Weekly ||
+                        recurrenceFrequency == RecurrenceFrequency.Monthly ||
+                        recurrenceFrequency == RecurrenceFrequency.Yearly)),
             'Days of the week can only be specified for recurrence rules with a weekly, monthly or yearly frequency'),
         assert(
             (daysOfTheMonth?.isEmpty ?? true) ||
@@ -49,8 +51,9 @@ class RecurrenceRule {
         assert(
             (daysOfTheMonth?.isEmpty ?? true) ||
                 ((daysOfTheMonth?.isNotEmpty ?? false) &&
-                    daysOfTheMonth.any((d) => d >= 1 || d <= 31)),
-            'Days of the month must be between 1 and 31 inclusive');
+                    (daysOfTheMonth.any((d) => d >= 1 || d <= 31) ||
+                        (daysOfTheMonth.any((d) => d >= -31 && d <= -1)))),
+            'Days of the month must be between 1 and 31 or -1 and -31 inclusive');
 
   RecurrenceRule.fromJson(Map<String, dynamic> json) {
     if (json == null) {
@@ -74,7 +77,7 @@ class RecurrenceRule {
     if (daysOfTheWeekIndices != null && daysOfTheWeekIndices is! List<int>) {
       daysOfTheWeek = daysOfTheWeekIndices
           .cast<int>()
-          .map((index) => DayOfWeek.values[index])
+          .map((index) => DayOfTheWeek.values[index])
           .toList();
     }
     List<Object> daysOfTheMonthObj = json[_daysOfTheMonthKey];

--- a/device_calendar/lib/src/models/recurrence_rule.dart
+++ b/device_calendar/lib/src/models/recurrence_rule.dart
@@ -21,19 +21,24 @@ class RecurrenceRule {
   /// The days of the month that this event occurs on. Only applicable to recurrence rules with a monthly frequency
   List<int> daysOfTheMonth;
 
+  /// The months of the year that the event occurs on. Only applicable to recurrence rules with a yearly frequency
+  List<int> monthsOfTheYear;
+
   final String _totalOccurrencesKey = 'totalOccurrences';
   final String _recurrenceFrequencyKey = 'recurrenceFrequency';
   final String _intervalKey = 'interval';
   final String _endDateKey = 'endDate';
   final String _daysOfTheWeekKey = 'daysOfTheWeek';
   final String _daysOfTheMonthKey = 'daysOfTheMonth';
+  final String _monthsOfTheYearKey = 'monthsOfTheYear';
 
   RecurrenceRule(this.recurrenceFrequency,
       {this.totalOccurrences,
       this.interval,
       this.endDate,
       this.daysOfTheWeek,
-      this.daysOfTheMonth})
+      this.daysOfTheMonth,
+      this.monthsOfTheYear})
       : assert(!(endDate != null && totalOccurrences != null),
             'Cannot specify both an end date and total occurrences for a recurring event'),
         assert(
@@ -46,14 +51,16 @@ class RecurrenceRule {
         assert(
             (daysOfTheMonth?.isEmpty ?? true) ||
                 ((daysOfTheMonth?.isNotEmpty ?? false) &&
-                    recurrenceFrequency == RecurrenceFrequency.Monthly),
-            'Days of the month can only be specified for recurrence rules with a monthly frequency'),
-        assert(
-            (daysOfTheMonth?.isEmpty ?? true) ||
-                ((daysOfTheMonth?.isNotEmpty ?? false) &&
+                    recurrenceFrequency == RecurrenceFrequency.Monthly &&
                     (daysOfTheMonth.any((d) => d >= 1 || d <= 31) ||
                         (daysOfTheMonth.any((d) => d >= -31 && d <= -1)))),
-            'Days of the month must be between 1 and 31 or -1 and -31 inclusive');
+            'Days of the month must be between 1 and 31 or -1 and -31 inclusive and can only be specified for recurrence rules with a monthly frequency'),
+        assert(
+            (monthsOfTheYear?.isEmpty ?? true) ||
+                ((monthsOfTheYear?.isNotEmpty ?? false) &&
+                    recurrenceFrequency == RecurrenceFrequency.Yearly &&
+                    monthsOfTheYear.any((d) => d >= 1 || d <= 12)),
+            'Months of the year must be between 1 and 12 inclusive and can only be specified for recurrence rules with a yearly frequency');
 
   RecurrenceRule.fromJson(Map<String, dynamic> json) {
     if (json == null) {
@@ -84,6 +91,10 @@ class RecurrenceRule {
     if (daysOfTheMonthObj != null && daysOfTheMonthObj is! List<int>) {
       daysOfTheMonth = daysOfTheMonthObj.cast<int>().toList();
     }
+    List<Object> monthsOfTheYearObj = json[_monthsOfTheYearKey];
+    if (monthsOfTheYearObj != null && monthsOfTheYearObj is! List<int>) {
+      monthsOfTheYear = monthsOfTheYearObj.cast<int>().toList();
+    }
   }
 
   Map<String, dynamic> toJson() {
@@ -103,6 +114,9 @@ class RecurrenceRule {
     }
     if (daysOfTheMonth != null) {
       data[_daysOfTheMonthKey] = daysOfTheMonth;
+    }
+    if (monthsOfTheYear != null) {
+      data[_monthsOfTheYearKey] = monthsOfTheYear;
     }
     return data;
   }

--- a/device_calendar/lib/src/models/recurrence_rule.dart
+++ b/device_calendar/lib/src/models/recurrence_rule.dart
@@ -1,3 +1,5 @@
+import 'package:device_calendar/src/common/day_of_week.dart';
+
 import '../common/error_messages.dart';
 import '../common/recurrence_frequency.dart';
 
@@ -12,16 +14,21 @@ class RecurrenceRule {
 
   /// The frequency of recurring events
   RecurrenceFrequency recurrenceFrequency;
+
+  List<DayOfWeek> daysOfWeek;
+
   final String _totalOccurrencesKey = 'totalOccurrences';
   final String _recurrenceFrequencyKey = 'recurrenceFrequency';
   final String _intervalKey = 'interval';
   final String _endDateKey = 'endDate';
+  final String _daysOfWeekKey = 'daysOfWeek';
 
   RecurrenceRule(
     this.recurrenceFrequency, {
     this.totalOccurrences,
     this.interval,
     this.endDate,
+    this.daysOfWeek,
   }) : assert(!(endDate != null && totalOccurrences != null),
             'Cannot specify both an end date and total occurrences for a recurring event');
 
@@ -43,6 +50,11 @@ class RecurrenceRule {
       endDate =
           DateTime.fromMillisecondsSinceEpoch(endDateMillisecondsSinceEpoch);
     }
+    /*List<int> daysOfWeekIndices = json[_daysOfWeekKey];
+    if (daysOfWeekIndices != null) {
+      daysOfWeek =
+          daysOfWeekIndices.map((index) => DayOfWeek.values[index]).toList();
+    }*/
   }
 
   Map<String, dynamic> toJson() {
@@ -55,7 +67,10 @@ class RecurrenceRule {
       data[_totalOccurrencesKey] = totalOccurrences;
     }
     if (endDate != null) {
-      data[_endDateKey] = endDate?.millisecondsSinceEpoch;
+      data[_endDateKey] = endDate.millisecondsSinceEpoch;
+    }
+    if (daysOfWeek != null) {
+      data[_daysOfWeekKey] = daysOfWeek.map((d) => d.index).toList();
     }
     return data;
   }

--- a/device_calendar/lib/src/models/recurrence_rule.dart
+++ b/device_calendar/lib/src/models/recurrence_rule.dart
@@ -22,16 +22,17 @@ class RecurrenceRule {
     this.totalOccurrences,
     this.interval,
     this.endDate,
-  }) : assert(!(endDate != null && totalOccurrences != null), 'Cannot specify both an end date and total occurrences for a recurring event');
+  }) : assert(!(endDate != null && totalOccurrences != null),
+            'Cannot specify both an end date and total occurrences for a recurring event');
 
   RecurrenceRule.fromJson(Map<String, dynamic> json) {
     if (json == null) {
-      throw new ArgumentError(ErrorMessages.fromJsonMapIsNull);
+      throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
     int recurrenceFrequencyIndex = json[_recurrenceFrequencyKey];
     if (recurrenceFrequencyIndex == null &&
         recurrenceFrequencyIndex >= RecurrenceFrequency.values.length) {
-      throw new ArgumentError(ErrorMessages.invalidRecurrencyFrequency);
+      throw ArgumentError(ErrorMessages.invalidRecurrencyFrequency);
     }
 
     recurrenceFrequency = RecurrenceFrequency.values[recurrenceFrequencyIndex];
@@ -45,7 +46,7 @@ class RecurrenceRule {
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
+    final Map<String, dynamic> data = Map<String, dynamic>();
     data[_recurrenceFrequencyKey] = recurrenceFrequency.index;
     if (interval != null) {
       data[_intervalKey] = interval;

--- a/device_calendar/lib/src/models/recurrence_rule.dart
+++ b/device_calendar/lib/src/models/recurrence_rule.dart
@@ -15,20 +15,20 @@ class RecurrenceRule {
   /// The frequency of recurring events
   RecurrenceFrequency recurrenceFrequency;
 
-  List<DayOfWeek> daysOfWeek;
+  List<DayOfWeek> daysOfTheWeek;
 
   final String _totalOccurrencesKey = 'totalOccurrences';
   final String _recurrenceFrequencyKey = 'recurrenceFrequency';
   final String _intervalKey = 'interval';
   final String _endDateKey = 'endDate';
-  final String _daysOfWeekKey = 'daysOfWeek';
+  final String _daysOfTheWeekKey = 'daysOfTheWeek';
 
   RecurrenceRule(
     this.recurrenceFrequency, {
     this.totalOccurrences,
     this.interval,
     this.endDate,
-    this.daysOfWeek,
+    this.daysOfTheWeek,
   }) : assert(!(endDate != null && totalOccurrences != null),
             'Cannot specify both an end date and total occurrences for a recurring event');
 
@@ -50,9 +50,9 @@ class RecurrenceRule {
       endDate =
           DateTime.fromMillisecondsSinceEpoch(endDateMillisecondsSinceEpoch);
     }
-    List<Object> daysOfWeekIndices = json[_daysOfWeekKey];
+    List<Object> daysOfWeekIndices = json[_daysOfTheWeekKey];
     if (daysOfWeekIndices != null && daysOfWeekIndices is! List<int>) {
-      daysOfWeek = daysOfWeekIndices
+      daysOfTheWeek = daysOfWeekIndices
           .cast<int>()
           .map((index) => DayOfWeek.values[index])
           .toList();
@@ -71,8 +71,8 @@ class RecurrenceRule {
     if (endDate != null) {
       data[_endDateKey] = endDate.millisecondsSinceEpoch;
     }
-    if (daysOfWeek != null) {
-      data[_daysOfWeekKey] = daysOfWeek.map((d) => d.index).toList();
+    if (daysOfTheWeek != null) {
+      data[_daysOfTheWeekKey] = daysOfTheWeek.map((d) => d.index).toList();
     }
     return data;
   }

--- a/device_calendar/lib/src/models/recurrence_rule.dart
+++ b/device_calendar/lib/src/models/recurrence_rule.dart
@@ -15,6 +15,7 @@ class RecurrenceRule {
   /// The frequency of recurring events
   RecurrenceFrequency recurrenceFrequency;
 
+  /// The days of the week associated with the recurring event should
   List<DayOfWeek> daysOfTheWeek;
 
   final String _totalOccurrencesKey = 'totalOccurrences';
@@ -29,8 +30,14 @@ class RecurrenceRule {
     this.interval,
     this.endDate,
     this.daysOfTheWeek,
-  }) : assert(!(endDate != null && totalOccurrences != null),
-            'Cannot specify both an end date and total occurrences for a recurring event');
+  })  : assert(!(endDate != null && totalOccurrences != null),
+            'Cannot specify both an end date and total occurrences for a recurring event'),
+        assert(
+            daysOfTheWeek.isNotEmpty &&
+                (recurrenceFrequency == RecurrenceFrequency.Weekly ||
+                    recurrenceFrequency == RecurrenceFrequency.Monthly &&
+                        recurrenceFrequency == RecurrenceFrequency.Yearly),
+            'Days of the week can only be specified for recurrence rules with a weekly, monthly or yearly frequency');
 
   RecurrenceRule.fromJson(Map<String, dynamic> json) {
     if (json == null) {

--- a/device_calendar/lib/src/models/reminder.dart
+++ b/device_calendar/lib/src/models/reminder.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+
+class Reminder {
+  int minutes;
+
+  Reminder({@required this.minutes});
+
+  Reminder.fromJson(Map<String, dynamic> json) {
+    minutes = json['minutes'] as int;
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{'minutes': minutes};
+  }
+}

--- a/device_calendar/lib/src/models/reminder.dart
+++ b/device_calendar/lib/src/models/reminder.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/foundation.dart';
 
 class Reminder {
+  /// The time when the reminder should be triggered expressed in terms of minutes before the start of the event
   int minutes;
 
-  Reminder({@required this.minutes});
+  Reminder({@required this.minutes})
+      : assert(minutes >= 0, 'Minutes must be greater than or equal than zero');
 
   Reminder.fromJson(Map<String, dynamic> json) {
     minutes = json['minutes'] as int;

--- a/device_calendar/lib/src/models/result.dart
+++ b/device_calendar/lib/src/models/result.dart
@@ -14,5 +14,5 @@ class Result<T> {
   }
 
   T data;
-  List<String> errorMessages = new List<String>();
+  List<String> errorMessages = List<String>();
 }

--- a/device_calendar/pubspec.yaml
+++ b/device_calendar/pubspec.yaml
@@ -7,7 +7,6 @@ homepage: https://github.com/builttoroam/flutter_plugins/tree/develop/device_cal
 dependencies:
   flutter:
     sdk: flutter
-  platform: ^2.2.1
 
 dev_dependencies:
   flutter_test:

--- a/device_calendar/pubspec.yaml
+++ b/device_calendar/pubspec.yaml
@@ -7,6 +7,7 @@ homepage: https://github.com/builttoroam/flutter_plugins/tree/develop/device_cal
 dependencies:
   flutter:
     sdk: flutter
+  platform: ^2.2.1
 
 dev_dependencies:
   flutter_test:

--- a/device_calendar/pubspec.yaml
+++ b/device_calendar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar
 description: A cross platform plugin for modifying calendars on the user's device.
-version: 0.2.1+1
+version: 1.0.0
 author: Built to Roam <info@builttoroam.com>
 homepage: https://github.com/builttoroam/flutter_plugins/tree/develop/device_calendar
 

--- a/device_calendar/test/device_calendar_test.dart
+++ b/device_calendar/test/device_calendar_test.dart
@@ -7,7 +7,7 @@ import '../lib/src/common/error_codes.dart';
 void main() {
   MethodChannel channel =
       const MethodChannel('plugins.builttoroam.com/device_calendar');
-  DeviceCalendarPlugin deviceCalendarPlugin = new DeviceCalendarPlugin();
+  DeviceCalendarPlugin deviceCalendarPlugin = DeviceCalendarPlugin();
 
   final List<MethodCall> log = <MethodCall>[];
 
@@ -60,7 +60,7 @@ void main() {
 
   test('RetrieveEvents_CalendarId_IsRequired', () async {
     final String calendarId = null;
-    final RetrieveEventsParams params = new RetrieveEventsParams();
+    final RetrieveEventsParams params = RetrieveEventsParams();
 
     final result =
         await deviceCalendarPlugin.retrieveEvents(calendarId, params);
@@ -107,7 +107,7 @@ void main() {
 
   test('CreateEvent_Arguments_Invalid', () async {
     final String fakeCalendarId = null;
-    final Event event = new Event(fakeCalendarId);
+    final Event event = Event(fakeCalendarId);
 
     final result = await deviceCalendarPlugin.createOrUpdateEvent(event);
     expect(result.isSuccess, false);
@@ -123,10 +123,10 @@ void main() {
     });
 
     final String fakeCalendarId = "fakeCalendarId";
-    final Event event = new Event(fakeCalendarId);
+    final Event event = Event(fakeCalendarId);
     event.title = "fakeEventTitle";
-    event.start = new DateTime.now();
-    event.end = event.start.add(new Duration(hours: 1));
+    event.start = DateTime.now();
+    event.end = event.start.add(Duration(hours: 1));
 
     final result = await deviceCalendarPlugin.createOrUpdateEvent(event);
     expect(result.isSuccess, true);
@@ -147,11 +147,11 @@ void main() {
     });
 
     final String fakeCalendarId = "fakeCalendarId";
-    final Event event = new Event(fakeCalendarId);
+    final Event event = Event(fakeCalendarId);
     event.eventId = "fakeEventId";
     event.title = "fakeEventTitle";
-    event.start = new DateTime.now();
-    event.end = event.start.add(new Duration(hours: 1));
+    event.start = DateTime.now();
+    event.end = event.start.add(Duration(hours: 1));
 
     final result = await deviceCalendarPlugin.createOrUpdateEvent(event);
     expect(result.isSuccess, true);


### PR DESCRIPTION
- Related to #109 
- Fixes #99.
- Event title has also been made optional to address #72 
- Made list of events and calendars read-only to address #113 
- Adds support for retrieving who the organiser is #73. This includes returning the email address of attendees
- Adds support for modifying attendees of an event #75 
- Adds support for creating reminders relative to start time of an event #105