### PR TITLE
Minor enhancements

### DIFF
--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.1.0 22nd January 2020
+## 3.1.0
 
 * Boolean variable `isDefault` added for issue [145](https://github.com/builttoroam/flutter_plugins/issues/145) (**NOTE**: This is not supported Android API 16 or lower, `isDefault` will always be false)
 * Events with 'null' title now defaults to 'New Event', issue [126](https://github.com/builttoroam/flutter_plugins/issues/126)

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.1.0 22nd January 2020
+
+* Boolean variable `isDefault` added for issue [145](https://github.com/builttoroam/flutter_plugins/issues/145) (**NOTE**: Not supported Android API 16 or lower, `isDefault` will always be false)
+* Events with 'null' title now defaults to 'New Event', issue [126](https://github.com/builttoroam/flutter_plugins/issues/126)
+
 ## 3.0.0 21st January 2020
 
 * **BREAKING CHANGE** Properties for the attendee model in `attendee.dart` file have been changed:

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 3.1.0 22nd January 2020
 
-* Boolean variable `isDefault` added for issue [145](https://github.com/builttoroam/flutter_plugins/issues/145) (**NOTE**: Not supported Android API 16 or lower, `isDefault` will always be false)
+* Boolean variable `isDefault` added for issue [145](https://github.com/builttoroam/flutter_plugins/issues/145) (**NOTE**: This is not supported Android API 16 or lower, `isDefault` will always be false)
 * Events with 'null' title now defaults to 'New Event', issue [126](https://github.com/builttoroam/flutter_plugins/issues/126)
+* Updated property summaries for issues [121](https://github.com/builttoroam/flutter_plugins/issues/121) and [122](https://github.com/builttoroam/flutter_plugins/issues/122)
+* Updated example documentation for issue [119](https://github.com/builttoroam/flutter_plugins/issues/119)
 
 ## 3.0.0 21st January 2020
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -517,7 +517,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         var url = cursor.getString(EVENT_PROJECTION_CUSTOM_APP_URI_INDEX)
 
         val event = Event()
-        event.title = title
+        event.title = title ?: "New Event"
         event.eventId = eventId.toString()
         event.calendarId = calendarId
         event.description = description

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -19,9 +19,11 @@ import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_RELATI
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_STATUS_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.ATTENDEE_TYPE_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION
+import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION_OLDER_API
 import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION_ACCESS_LEVEL_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION_DISPLAY_NAME_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION_ID_INDEX
+import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJECTION_IS_PRIMARY_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_ALL_DAY_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_BEGIN_INDEX
@@ -149,7 +151,12 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         if (arePermissionsGranted()) {
             val contentResolver: ContentResolver? = _context?.contentResolver
             val uri: Uri = CalendarContract.Calendars.CONTENT_URI
-            val cursor: Cursor? = contentResolver?.query(uri, CALENDAR_PROJECTION, null, null, null)
+            val cursor: Cursor? = if (atLeastAPI(17)) {
+                contentResolver?.query(uri, CALENDAR_PROJECTION, null, null, null)
+            } else {
+                contentResolver?.query(uri, CALENDAR_PROJECTION_OLDER_API, null, null, null)
+            }
+
             val calendars: MutableList<Calendar> = mutableListOf()
             try {
                 while (cursor?.moveToNext() == true) {
@@ -181,7 +188,11 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
             val contentResolver: ContentResolver? = _context?.contentResolver
             val uri: Uri = CalendarContract.Calendars.CONTENT_URI
-            val cursor: Cursor? = contentResolver?.query(ContentUris.withAppendedId(uri, calendarIdNumber), CALENDAR_PROJECTION, null, null, null)
+            val cursor: Cursor? = if (atLeastAPI(17)) {
+                contentResolver?.query(uri, CALENDAR_PROJECTION, null, null, null)
+            } else {
+                contentResolver?.query(uri, CALENDAR_PROJECTION_OLDER_API, null, null, null)
+            }
 
             try {
                 if (cursor?.moveToFirst() == true) {
@@ -478,6 +489,14 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
         val calendar = Calendar(calId.toString(), displayName)
         calendar.isReadOnly = isCalendarReadOnly(accessLevel)
+
+        if (atLeastAPI(17)) {
+            val isPrimary = cursor.getString(CALENDAR_PROJECTION_IS_PRIMARY_INDEX)
+            calendar.isDefault = isPrimary == "1"
+        }
+        else {
+            calendar.isDefault = false
+        }
 
         return calendar
     }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/Constants.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/Constants.kt
@@ -9,8 +9,20 @@ class Constants {
         const val CALENDAR_PROJECTION_DISPLAY_NAME_INDEX: Int = 2
         const val CALENDAR_PROJECTION_OWNER_ACCOUNT_INDEX: Int = 3
         const val CALENDAR_PROJECTION_ACCESS_LEVEL_INDEX: Int = 4
+        const val CALENDAR_PROJECTION_IS_PRIMARY_INDEX: Int = 5
 
+        // API 17 or higher
         val CALENDAR_PROJECTION: Array<String> = arrayOf(
+                CalendarContract.Calendars._ID,                           // 0
+                CalendarContract.Calendars.ACCOUNT_NAME,                  // 1
+                CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,         // 2
+                CalendarContract.Calendars.OWNER_ACCOUNT,                 // 3
+                CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,         // 4
+                CalendarContract.Calendars.IS_PRIMARY                     // 5
+        )
+
+        // API 16 or lower
+        val CALENDAR_PROJECTION_OLDER_API: Array<String> = arrayOf(
                 CalendarContract.Calendars._ID,                           // 0
                 CalendarContract.Calendars.ACCOUNT_NAME,                  // 1
                 CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,         // 2

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Calendar.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Calendar.kt
@@ -2,4 +2,5 @@ package com.builttoroam.devicecalendar.models
 
 class Calendar(val id: String, val name: String) {
     var isReadOnly: Boolean = false
+    var isDefault: Boolean = false
 }

--- a/device_calendar/example/README.md
+++ b/device_calendar/example/README.md
@@ -1,13 +1,11 @@
-# device_calendar_example
+# Examples
 
-Demonstrates how to use the device_calendar plugin.
+Most of the APIs are covered in [calendar_event.dart](https://github.com/builttoroam/flutter_plugins/blob/master/device_calendar/example/lib/presentation/pages/calendar_event.dart) or [calendar_events.dart](https://github.com/builttoroam/flutter_plugins/blob/master/device_calendar/example/lib/presentation/pages/calendar_events.dart) files in the example app.
+You'll be able to get a reference of how the APIs are used.
 
-## Getting Started
+For a full API reference, the documentation can be found at [pub.dev](https://pub.dev/documentation/device_calendar/latest/device_calendar/device_calendar-library.html).
 
-For help getting started with Flutter, view our online
-[documentation](https://flutter.io/).
-
-## Attendees Parameters
+## Attendee Examples
 
 Examples below present on how to initialise an `Attendee` model in Dart:
 
@@ -29,10 +27,27 @@ Examples below present on how to initialise an `Attendee` model in Dart:
         role: AttendeeRole.Optional);
     ```
 
-## Recurrence Rule Parameters
+## Reminder Examples
+
+Examples below present on how to initialise a `Reminder` model in Dart:
+
+* 30 minutes
+
+    ```dart
+    Reminder(minutes: 30);
+    ```
+
+* 1 day
+
+    ```dart
+    Reminder(minutes: 1440);
+    ```
+
+## Recurrence Rule Examples
 
 Examples below present sample parameters of recurrence rules received by each platform and required properties for the `RecurrenceRule` model in Dart.\
-Please note that receiving monthly and yearly recurrence parameters are slightly different for the two platforms.\
+**Please note**: Receiving monthly and yearly recurrence parameters are slightly different for the two platforms.
+
 You can find more standard examples at [iCalendar.org](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html).
 
 ### **Daily Rule**

--- a/device_calendar/example/lib/presentation/pages/calendars.dart
+++ b/device_calendar/example/lib/presentation/pages/calendars.dart
@@ -74,6 +74,12 @@ class _CalendarsPageState extends State<CalendarsPage> {
                             style: Theme.of(context).textTheme.subhead,
                           ),
                         ),
+                        Container(
+                          margin: const EdgeInsets.fromLTRB(0, 0, 5.0, 0),
+                          padding: const EdgeInsets.all(3.0),
+                          decoration: BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+                          child: Text('Default'),
+                        ),
                         Icon(_calendars[index].isReadOnly
                             ? Icons.lock
                             : Icons.lock_open)

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -17,6 +17,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let id: String
         let name: String
         let isReadOnly: Bool
+        let isDefault: Bool
     }
     
     struct Event: Codable {
@@ -134,9 +135,10 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
     private func retrieveCalendars(_ result: @escaping FlutterResult) {
         checkPermissionsThenExecute(permissionsGrantedAction: {
             let ekCalendars = self.eventStore.calendars(for: .event)
+            let defaultCalendar = self.eventStore.defaultCalendarForNewEvents
             var calendars = [Calendar]()
             for ekCalendar in ekCalendars {
-                let calendar = Calendar(id: ekCalendar.calendarIdentifier, name: ekCalendar.title, isReadOnly: !ekCalendar.allowsContentModifications)
+                let calendar = Calendar(id: ekCalendar.calendarIdentifier, name: ekCalendar.title, isReadOnly: !ekCalendar.allowsContentModifications, isDefault: defaultCalendar?.calendarIdentifier == ekCalendar.calendarIdentifier)
                 calendars.append(calendar)
             }
             

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -219,7 +219,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let event = Event(
             eventId: ekEvent.eventIdentifier,
             calendarId: calendarId,
-            title: ekEvent.title,
+            title: ekEvent.title ?? "New Event",
             description: ekEvent.notes,
             start: Int64(ekEvent.startDate.millisecondsSinceEpoch),
             end: Int64(ekEvent.endDate.millisecondsSinceEpoch),

--- a/device_calendar/lib/src/models/attendee.dart
+++ b/device_calendar/lib/src/models/attendee.dart
@@ -7,7 +7,7 @@ import 'platform_specifics/ios/attendee_details.dart';
 
 /// A person attending an event
 class Attendee {
-  /// The name of the attendee. Currently has no effect when saving attendees on iOS.
+  /// The name of the attendee
   String name;
 
   /// The email address of the attendee
@@ -19,7 +19,7 @@ class Attendee {
   /// Read-only. Returns true if the attendee is an organiser, else false
   bool isOrganiser = false;
 
-  /// Details about the attendee that are specific to iOS. Currently has no effect when saving attendees on iOS.
+  /// Details about the attendee that are specific to iOS.
   /// When reading details for an existing event, this will only be populated on iOS devices.
   IosAttendeeDetails iosAttendeeDetails;
 

--- a/device_calendar/lib/src/models/calendar.dart
+++ b/device_calendar/lib/src/models/calendar.dart
@@ -1,15 +1,15 @@
 /// A calendar on the user's device
 class Calendar {
-  /// The unique identifier for this calendar
+  /// Read-only. The unique identifier for this calendar
   String id;
 
   /// The name of this calendar
   String name;
 
-  /// If the calendar is read-only
+  /// Read-only. If the calendar is read-only
   bool isReadOnly;
 
-  /// If the calendar is the default
+  /// Read-only. If the calendar is the default
   bool isDefault;
 
   Calendar({this.id, this.name, this.isReadOnly, this.isDefault});

--- a/device_calendar/lib/src/models/calendar.dart
+++ b/device_calendar/lib/src/models/calendar.dart
@@ -9,16 +9,20 @@ class Calendar {
   /// If the calendar is read-only
   bool isReadOnly;
 
-  Calendar({this.id, this.name, this.isReadOnly});
+  /// If the calendar is the default
+  bool isDefault;
+
+  Calendar({this.id, this.name, this.isReadOnly, this.isDefault});
 
   Calendar.fromJson(Map<String, dynamic> json) {
     id = json['id'];
     name = json['name'];
     isReadOnly = json['isReadOnly'];
+    isDefault = json['isDefault'];
   }
 
   Map<String, dynamic> toJson() {
-    final data = <String, dynamic>{ 'id': id, 'name': name, 'isReadOnly': isReadOnly };
+    final data = <String, dynamic>{ 'id': id, 'name': name, 'isReadOnly': isReadOnly, 'isDefault': isDefault };
     
     return data;
   }

--- a/device_calendar/lib/src/models/event.dart
+++ b/device_calendar/lib/src/models/event.dart
@@ -5,7 +5,7 @@ import 'recurrence_rule.dart';
 
 /// An event associated with a calendar
 class Event {
-  /// The unique identifier for this event
+  /// Read-only. The unique identifier for this event. This is auto-generated when a new event is created
   String eventId;
 
   /// The identifier of the calendar that this event is associated with

--- a/device_calendar/pubspec.yaml
+++ b/device_calendar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar
 description: A cross platform plugin for modifying calendars on the user's device.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/builttoroam/flutter_plugins/tree/master/device_calendar
 
 dependencies:


### PR DESCRIPTION
**Improvements**
* Added some information and examples (issue #119)
* Added "Read-only" text to read-only property summaries (issues #121, #122)
* Both platforms will default the event title to "New Event" if it is null (issue #126)
* Applied Android support for isDefault calendar (#145)

**Notes**
I've updated the changelog without a date, I'll make sure to update it before we release this.