### PR TITLE
Delete instance + DayOfWeekGroup enum update

### DIFF
--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added to retrieve colour for calendars. Thanks to [nadavfima](https://github.com/nadavfima) for the contribution and PR to add colour support for both Android and iOS
 * Added compatibility with a new Flutter plugin for Android. Thanks to the PR submitted by [RohitKumarMishra](https://github.com/RohitKumarMishra)
 * [Android] Fixed all day timezone issue [164](https://github.com/builttoroam/flutter_plugins/issues/164)
+* Added support for deleting individual or multiple instances of a recurring event for issue [108](https://github.com/builttoroam/flutter_plugins/issues/108)
 
 ## 3.0.0+3 3rd February 2020
 

--- a/device_calendar/CHANGELOG.md
+++ b/device_calendar/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Updated property summaries for issues [121](https://github.com/builttoroam/flutter_plugins/issues/121) and [122](https://github.com/builttoroam/flutter_plugins/issues/122)
 * Updated example documentation for issue [119](https://github.com/builttoroam/flutter_plugins/issues/119)
 * Read-only calendars cannot be edited or deleted for the example app
-* Added `DayOfWeekGroup` enum and an extension `getDays` to get corresponding dates of the enum values (**NOTE**: `DayOfWeekGroup.Custom.getDays` will return an empty list)
+* Added `DayOfWeekGroup` enum and an extension `getDays` to get corresponding dates of the enum values
 * Added to retrieve colour for calendars. Thanks to [nadavfima](https://github.com/nadavfima) for the contribution and PR to add colour support for both Android and iOS
 * Added compatibility with a new Flutter plugin for Android. Thanks to the PR submitted by [RohitKumarMishra](https://github.com/RohitKumarMishra)
 * [Android] Fixed all day timezone issue [164](https://github.com/builttoroam/flutter_plugins/issues/164)

--- a/device_calendar/README.md
+++ b/device_calendar/README.md
@@ -11,7 +11,9 @@ A cross platform plugin for modifying calendars on the user's device.
 * Retrieve calendars on the user's device
 * Retrieve events associated with a calendar
 * Ability to add, update or delete events from a calendar
-* Ability to set up recurring events (NOTE: deleting a recurring event will currently delete all instances of it)
+* Ability to set up, edit or delete recurring events
+  * **NOTE**: Editing a recurring event will currently edit all instances of it
+  * **NOTE**: Deleting multiple instances in **Android** takes time to update, you'll see the changes after a few seconds
 * Ability to add, modify or remove attendees and receive if an attendee is an organiser for an event
 * Ability to setup reminders for an event
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -3,7 +3,6 @@ package com.builttoroam.devicecalendar
 import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.app.Service
 import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.ContentValues

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -53,6 +53,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private val ROLE_ARGUMENT = "role"
     private val REMINDERS_ARGUMENT = "reminders"
     private val MINUTES_ARGUMENT = "minutes"
+    private val FOLLOWING_INSTANCES = "followingInstances"
 
     private lateinit var _registrar: Registrar
     private lateinit var _calendarDelegate: CalendarDelegate
@@ -113,8 +114,9 @@ class DeviceCalendarPlugin() : MethodCallHandler {
                 val eventId = call.argument<String>(EVENT_ID_ARGUMENT)
                 val startDate = call.argument<Long>(EVENT_START_DATE_ARGUMENT)
                 val endDate = call.argument<Long>(EVENT_END_DATE_ARGUMENT)
+                val followingInstances = call.argument<Boolean>(FOLLOWING_INSTANCES)
 
-                _calendarDelegate.deleteEvent(calendarId!!, eventId!!, result, startDate, endDate)
+                _calendarDelegate.deleteEvent(calendarId!!, eventId!!, result, startDate, endDate, followingInstances)
             }
             else -> {
                 result.notImplemented()

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -23,6 +23,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private val RETRIEVE_CALENDARS_METHOD = "retrieveCalendars"
     private val RETRIEVE_EVENTS_METHOD = "retrieveEvents"
     private val DELETE_EVENT_METHOD = "deleteEvent"
+    private val DELETE_EVENT_INSTANCE_METHOD = "deleteEventInstance"
     private val CREATE_OR_UPDATE_EVENT_METHOD = "createOrUpdateEvent"
 
     // Method arguments
@@ -106,6 +107,14 @@ class DeviceCalendarPlugin() : MethodCallHandler {
                 val eventId = call.argument<String>(EVENT_ID_ARGUMENT)
 
                 _calendarDelegate.deleteEvent(calendarId!!, eventId!!, result)
+            }
+            DELETE_EVENT_INSTANCE_METHOD -> {
+                val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
+                val eventId = call.argument<String>(EVENT_ID_ARGUMENT)
+                val startDate = call.argument<Long>(EVENT_START_DATE_ARGUMENT)
+                val endDate = call.argument<Long>(EVENT_END_DATE_ARGUMENT)
+
+                _calendarDelegate.deleteEvent(calendarId!!, eventId!!, result, startDate, endDate)
             }
             else -> {
                 result.notImplemented()

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/Constants.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/Constants.kt
@@ -58,6 +58,20 @@ class Constants {
                 CalendarContract.Events.CUSTOM_APP_URI
         )
 
+        const val EVENT_INSTANCE_DELETION_ID_INDEX: Int = 0
+        const val EVENT_INSTANCE_DELETION_RRULE_INDEX: Int = 1
+        const val EVENT_INSTANCE_DELETION_LAST_DATE_INDEX: Int = 2
+        const val EVENT_INSTANCE_DELETION_BEGIN_INDEX: Int = 3
+        const val EVENT_INSTANCE_DELETION_END_INDEX: Int = 4
+
+        val EVENT_INSTANCE_DELETION: Array<String> = arrayOf(
+                CalendarContract.Instances.EVENT_ID,
+                CalendarContract.Events.RRULE,
+                CalendarContract.Events.LAST_DATE,
+                CalendarContract.Instances.BEGIN,
+                CalendarContract.Instances.END
+        )
+
         const val ATTENDEE_ID_INDEX: Int = 0
         const val ATTENDEE_EVENT_ID_INDEX: Int = 1
         const val ATTENDEE_NAME_INDEX: Int = 2

--- a/device_calendar/example/lib/presentation/event_item.dart
+++ b/device_calendar/example/lib/presentation/event_item.dart
@@ -2,6 +2,8 @@ import 'package:device_calendar/device_calendar.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import 'recurring_event_dialog.dart';
+
 class EventItem extends StatelessWidget {
   final Event _calendarEvent;
   final DeviceCalendarPlugin _deviceCalendarPlugin;
@@ -168,7 +170,7 @@ class EventItem extends StatelessWidget {
                   ),
                   IconButton(
                     onPressed: () async {
-                      await showDialog<Null>(
+                      await showDialog<bool>(
                         context: context,
                         barrierDismissible: false,
                         builder: (BuildContext context) {
@@ -195,38 +197,11 @@ class EventItem extends StatelessWidget {
                             );
                           }
                           else {
-                            return AlertDialog(
-                              title: Text('Are you sure you want to delete this event?'),
-                              actions: [
-                                FlatButton(
-                                  onPressed: () {
-                                    Navigator.of(context).pop();
-                                  },
-                                  child: Text('Cancel'),
-                                ),
-                                FlatButton(
-                                  onPressed: () async {
-                                    Navigator.of(context).pop();
-                                    _onLoadingStarted();
-                                    final deleteResult = await _deviceCalendarPlugin.deleteEvent(_calendarEvent.calendarId, _calendarEvent.eventId);
-                                    _onDeleteFinished(deleteResult.isSuccess && deleteResult.data);
-                                  },
-                                  child: Text('Delete All'),
-                                ),
-                                FlatButton(
-                                  onPressed: () async {
-                                    Navigator.of(context).pop();
-                                    _onLoadingStarted();
-                                    final deleteResult = await _deviceCalendarPlugin.deleteEventInstance(
-                                      _calendarEvent.calendarId,
-                                      _calendarEvent.eventId,
-                                      _calendarEvent.start.millisecondsSinceEpoch,
-                                      _calendarEvent.end.millisecondsSinceEpoch);
-                                    _onDeleteFinished(deleteResult.isSuccess && deleteResult.data);
-                                  },
-                                  child: Text('Delete Instance'),
-                                ),
-                              ],
+                            return RecurringEventDialog(
+                              _deviceCalendarPlugin,
+                              _calendarEvent,
+                              _onLoadingStarted,
+                              _onDeleteFinished
                             );
                           }
                         }

--- a/device_calendar/example/lib/presentation/event_item.dart
+++ b/device_calendar/example/lib/presentation/event_item.dart
@@ -169,12 +169,12 @@ class EventItem extends StatelessWidget {
                   IconButton(
                     onPressed: () async {
                       await showDialog<Null>(
-                          context: context,
-                          barrierDismissible: false,
-                          builder: (BuildContext context) {
+                        context: context,
+                        barrierDismissible: false,
+                        builder: (BuildContext context) {
+                          if (_calendarEvent.recurrenceRule == null) {
                             return AlertDialog(
-                              title: Text(
-                                  'Are you sure you want to delete this event?'),
+                              title: Text('Are you sure you want to delete this event?'),
                               actions: [
                                 FlatButton(
                                   onPressed: () {
@@ -186,18 +186,51 @@ class EventItem extends StatelessWidget {
                                   onPressed: () async {
                                     Navigator.of(context).pop();
                                     _onLoadingStarted();
-                                    final deleteResult =
-                                        await _deviceCalendarPlugin.deleteEvent(
-                                            _calendarEvent.calendarId,
-                                            _calendarEvent.eventId);
-                                    _onDeleteFinished(deleteResult.isSuccess &&
-                                        deleteResult.data);
+                                    final deleteResult = await _deviceCalendarPlugin.deleteEvent(_calendarEvent.calendarId, _calendarEvent.eventId);
+                                    _onDeleteFinished(deleteResult.isSuccess && deleteResult.data);
                                   },
-                                  child: Text('Ok'),
+                                  child: Text('Delete'),
                                 ),
                               ],
                             );
-                          });
+                          }
+                          else {
+                            return AlertDialog(
+                              title: Text('Are you sure you want to delete this event?'),
+                              actions: [
+                                FlatButton(
+                                  onPressed: () {
+                                    Navigator.of(context).pop();
+                                  },
+                                  child: Text('Cancel'),
+                                ),
+                                FlatButton(
+                                  onPressed: () async {
+                                    Navigator.of(context).pop();
+                                    _onLoadingStarted();
+                                    final deleteResult = await _deviceCalendarPlugin.deleteEvent(_calendarEvent.calendarId, _calendarEvent.eventId);
+                                    _onDeleteFinished(deleteResult.isSuccess && deleteResult.data);
+                                  },
+                                  child: Text('Delete All'),
+                                ),
+                                FlatButton(
+                                  onPressed: () async {
+                                    Navigator.of(context).pop();
+                                    _onLoadingStarted();
+                                    final deleteResult = await _deviceCalendarPlugin.deleteEventInstance(
+                                      _calendarEvent.calendarId,
+                                      _calendarEvent.eventId,
+                                      _calendarEvent.start.millisecondsSinceEpoch,
+                                      _calendarEvent.end.millisecondsSinceEpoch);
+                                    _onDeleteFinished(deleteResult.isSuccess && deleteResult.data);
+                                  },
+                                  child: Text('Delete Instance'),
+                                ),
+                              ],
+                            );
+                          }
+                        }
+                      );
                     },
                     icon: Icon(Icons.delete),
                   ),

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -591,17 +591,33 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                 ),
               ),
               if (!_calendar.isReadOnly && (_event.eventId?.isNotEmpty ?? false)) ...[
-                RaisedButton(
-                  key: Key('deleteEventButton'),
-                  textColor: Colors.white,
-                  color: Colors.red,
-                  child: Text('Delete'),
-                  onPressed: () async {
-                    await _deviceCalendarPlugin.deleteEvent(
-                        _calendar.id, _event.eventId);
-                    Navigator.pop(context, true);
-                  },
-                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: <Widget>[
+                    RaisedButton(
+                      key: Key('deleteEventButton'),
+                      textColor: Colors.white,
+                      color: Colors.red,
+                      child: Text(_isRecurringEvent ? 'Delete All' : 'Delete'),
+                      onPressed: () async {
+                        await _deviceCalendarPlugin.deleteEvent(_calendar.id, _event.eventId);
+                        Navigator.pop(context, true);
+                      },
+                    ),
+                    if (_isRecurringEvent) ...[
+                      RaisedButton(
+                        key: Key('deleteInstnaceEventButton'),
+                        textColor: Colors.white,
+                        color: Colors.red,
+                        child: Text('Delete Instance'),
+                        onPressed: () async {
+                          await _deviceCalendarPlugin.deleteEventInstance(_calendar.id, _event.eventId, _event.start.millisecondsSinceEpoch, _event.end.millisecondsSinceEpoch);
+                          Navigator.pop(context, true);
+                        },
+                      ),
+                    ]
+                  ]
+                )
               ]
             ],
           ),

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -747,8 +747,6 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
       case DayOfWeekGroup.None:
         _daysOfWeek.clear();
         break;
-      default: // DayOfWeekGroup.Custom, it shouldn't be changed
-        break;
     }
   }
 
@@ -771,9 +769,9 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
     else if (deepEquality(_daysOfWeek, DayOfWeekGroup.Alldays.getDays) && _dayOfWeekGroup != DayOfWeekGroup.Alldays) {
       _dayOfWeekGroup = DayOfWeekGroup.Alldays;
     }
-    // Otherwise, set as Custom
+    // Otherwise null
     else {
-      _dayOfWeekGroup = DayOfWeekGroup.Custom;
+      _dayOfWeekGroup = null;
     }
   }
 

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -740,7 +740,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
     switch (_dayOfWeekGroup) {
       case DayOfWeekGroup.Weekday:
       case DayOfWeekGroup.Weekend:
-      case DayOfWeekGroup.Alldays:
+      case DayOfWeekGroup.AllDays:
         _daysOfWeek.clear();
         _daysOfWeek.addAll(days.where((a) => _daysOfWeek.every((b) => a != b)));
         break;
@@ -766,8 +766,8 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
       _dayOfWeekGroup = DayOfWeekGroup.Weekend;
     }
     // If _daysOfWeek contains all days
-    else if (deepEquality(_daysOfWeek, DayOfWeekGroup.Alldays.getDays) && _dayOfWeekGroup != DayOfWeekGroup.Alldays) {
-      _dayOfWeekGroup = DayOfWeekGroup.Alldays;
+    else if (deepEquality(_daysOfWeek, DayOfWeekGroup.AllDays.getDays) && _dayOfWeekGroup != DayOfWeekGroup.AllDays) {
+      _dayOfWeekGroup = DayOfWeekGroup.AllDays;
     }
     // Otherwise null
     else {

--- a/device_calendar/example/lib/presentation/pages/calendar_event.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_event.dart
@@ -14,15 +14,13 @@ enum RecurrenceRuleEndType { Indefinite, MaxOccurrences, SpecifiedEndDate }
 class CalendarEventPage extends StatefulWidget {
   final Calendar _calendar;
   final Event _event;
+  final RecurringEventDialog _recurringEventDialog;
 
-  final VoidCallback _onLoadingStarted;
-  final Function(bool) _onDeleteFinished;
-
-  CalendarEventPage(this._calendar, [this._event, this._onLoadingStarted, this._onDeleteFinished]);
+  CalendarEventPage(this._calendar, [this._event, this._recurringEventDialog]);
 
   @override
   _CalendarEventPageState createState() {
-    return _CalendarEventPageState(_calendar, _event, _onLoadingStarted, _onDeleteFinished);
+    return _CalendarEventPageState(_calendar, _event, _recurringEventDialog);
   }
 }
 
@@ -33,9 +31,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
 
   Event _event;
   DeviceCalendarPlugin _deviceCalendarPlugin;
-
-  VoidCallback _onLoadingStarted;
-  Function(bool) _onDeleteFinished;
+  RecurringEventDialog _recurringEventDialog;
 
   DateTime _startDate;
   TimeOfDay _startTime;
@@ -63,8 +59,9 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
   List<Attendee> _attendees = List<Attendee>();
   List<Reminder> _reminders = List<Reminder>();
   
-  _CalendarEventPageState(this._calendar, this._event, this._onLoadingStarted, this._onDeleteFinished) {
+  _CalendarEventPageState(this._calendar, this._event, this._recurringEventDialog) {
     _deviceCalendarPlugin = DeviceCalendarPlugin();
+    _recurringEventDialog = this._recurringEventDialog;
 
     _attendees = List<Attendee>();
     _reminders = List<Reminder>();
@@ -613,12 +610,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                         context: context,
                         barrierDismissible: false,
                         builder: (BuildContext context) {
-                          return RecurringEventDialog(
-                            _deviceCalendarPlugin,
-                            _event,
-                            _onLoadingStarted,
-                            _onDeleteFinished,
-                          );
+                          return _recurringEventDialog;
                         }
                       );
                     }

--- a/device_calendar/example/lib/presentation/pages/calendar_events.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_events.dart
@@ -19,7 +19,7 @@ class CalendarEventsPage extends StatefulWidget {
 
 class _CalendarEventsPageState extends State<CalendarEventsPage> {
   final Calendar _calendar;
-  BuildContext _scaffoldContext;
+  final GlobalKey<ScaffoldState> _scaffoldstate = GlobalKey<ScaffoldState>();
 
   DeviceCalendarPlugin _deviceCalendarPlugin;
   List<Event> _calendarEvents;
@@ -38,6 +38,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      key: _scaffoldstate,
       appBar: AppBar(title: Text('${_calendar.name} events')),
       body: (_calendarEvents?.isNotEmpty ?? false)
           ? Stack(
@@ -96,7 +97,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     if (deleteSucceeded) {
       await _retrieveCalendarEvents();
     } else {
-      Scaffold.of(_scaffoldContext).showSnackBar(SnackBar(
+        _scaffoldstate.currentState.showSnackBar(SnackBar(
         content: Text('Oops, we ran into an issue deleting the event'),
         backgroundColor: Colors.red,
         duration: Duration(seconds: 5),

--- a/device_calendar/example/lib/presentation/pages/calendar_events.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_events.dart
@@ -110,7 +110,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   Future _onTapped(Event event) async {
     final refreshEvents = await Navigator.push(context,
         MaterialPageRoute(builder: (BuildContext context) {
-      return CalendarEventPage(_calendar, event);
+      return CalendarEventPage(_calendar, event, _onLoading, _onDeletedFinished);
     }));
     if (refreshEvents != null && refreshEvents) {
       await _retrieveCalendarEvents();

--- a/device_calendar/example/lib/presentation/pages/calendar_events.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_events.dart
@@ -4,6 +4,7 @@ import 'package:device_calendar/device_calendar.dart';
 import 'package:flutter/material.dart';
 
 import '../event_item.dart';
+import '../recurring_event_dialog.dart';
 import 'calendar_event.dart';
 
 class CalendarEventsPage extends StatefulWidget {
@@ -111,7 +112,13 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   Future _onTapped(Event event) async {
     final refreshEvents = await Navigator.push(context,
         MaterialPageRoute(builder: (BuildContext context) {
-      return CalendarEventPage(_calendar, event, _onLoading, _onDeletedFinished);
+      return CalendarEventPage(_calendar, event,
+        RecurringEventDialog(
+          _deviceCalendarPlugin,
+          event,
+          _onLoading,
+          _onDeletedFinished,
+        ),);
     }));
     if (refreshEvents != null && refreshEvents) {
       await _retrieveCalendarEvents();

--- a/device_calendar/example/lib/presentation/recurring_event_dialog.dart
+++ b/device_calendar/example/lib/presentation/recurring_event_dialog.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:device_calendar/device_calendar.dart';
+
+class RecurringEventDialog extends StatefulWidget {
+  final DeviceCalendarPlugin _deviceCalendarPlugin;
+  final Event _calendarEvent;
+
+  final VoidCallback _onLoadingStarted;
+  final Function(bool) _onDeleteFinished;
+
+  RecurringEventDialog(
+    this._deviceCalendarPlugin,
+    this._calendarEvent,
+    this._onLoadingStarted,
+    this._onDeleteFinished,
+    {Key key}) : super(key: key);
+
+  _RecurringEventDialogState createState() =>
+  _RecurringEventDialogState(_deviceCalendarPlugin, _calendarEvent, onLoadingStarted: _onLoadingStarted, onDeleteFinished: _onDeleteFinished);
+}
+
+class _RecurringEventDialogState extends State<RecurringEventDialog> {
+  DeviceCalendarPlugin _deviceCalendarPlugin;
+  Event _calendarEvent;
+  VoidCallback _onLoadingStarted;
+  Function(bool) _onDeleteFinished;
+
+  _RecurringEventDialogState(DeviceCalendarPlugin deviceCalendarPlugin, Event calendarEvent, {VoidCallback onLoadingStarted, Function(bool) onDeleteFinished}) {
+    _deviceCalendarPlugin = deviceCalendarPlugin;
+    _calendarEvent = calendarEvent;
+    _onLoadingStarted = onLoadingStarted;
+    _onDeleteFinished = onDeleteFinished;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleDialog(
+        title: Text('Are you sure you want to delete this event?'),
+        children: <Widget>[
+          SimpleDialogOption(
+            child: Text('This instance only'),
+            onPressed: () async {
+              Navigator.of(context).pop(true);
+              _onLoadingStarted();
+              final deleteResult = await _deviceCalendarPlugin.deleteEventInstance(
+                _calendarEvent.calendarId,
+                _calendarEvent.eventId,
+                _calendarEvent.start.millisecondsSinceEpoch,
+                _calendarEvent.end.millisecondsSinceEpoch,
+                false);
+              _onDeleteFinished(deleteResult.isSuccess && deleteResult.data);
+            },
+          ),
+          SimpleDialogOption(
+            child: Text('This and following instances'),
+            onPressed: () async {
+              Navigator.of(context).pop(true);
+              _onLoadingStarted();
+              final deleteResult = await _deviceCalendarPlugin.deleteEventInstance(
+                _calendarEvent.calendarId,
+                _calendarEvent.eventId,
+                _calendarEvent.start.millisecondsSinceEpoch,
+                _calendarEvent.end.millisecondsSinceEpoch,
+                true);
+              _onDeleteFinished(deleteResult.isSuccess && deleteResult.data);
+            },
+          ),
+          SimpleDialogOption(
+            child: Text('All instances'),
+            onPressed: () async {
+              Navigator.of(context).pop(true);
+              _onLoadingStarted();
+              final deleteResult = await _deviceCalendarPlugin.deleteEvent(_calendarEvent.calendarId, _calendarEvent.eventId);
+              _onDeleteFinished(deleteResult.isSuccess && deleteResult.data);
+            },
+          ),
+          SimpleDialogOption(
+            child: Text('Cancel'),
+            onPressed: () { Navigator.of(context).pop(false); },
+          )
+        ],
+      );
+  }
+}

--- a/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/device_calendar/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -102,6 +102,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
     let roleArgument = "role"
     let remindersArgument = "reminders"
     let minutesArgument = "minutes"
+    let followingInstancesArgument = "followingInstances"
     let validFrequencyTypes = [EKRecurrenceFrequency.daily, EKRecurrenceFrequency.weekly, EKRecurrenceFrequency.monthly, EKRecurrenceFrequency.yearly]
     
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -542,6 +543,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
             let eventId = arguments[eventIdArgument] as! String
             let startDateNumber = arguments[eventStartDateArgument] as? NSNumber
             let endDateNumber = arguments[eventEndDateArgument] as? NSNumber
+            let followingInstances = arguments[followingInstancesArgument] as? Bool
             
             let ekCalendar = self.eventStore.calendar(withIdentifier: calendarId)
             if ekCalendar == nil {
@@ -554,7 +556,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 return
             }
             
-            if (startDateNumber == nil && endDateNumber == nil) {
+            if (startDateNumber == nil && endDateNumber == nil && followingInstances == nil) {
                 let ekEvent = self.eventStore.event(withIdentifier: eventId)
                 if ekEvent == nil {
                     self.finishWithEventNotFoundError(result: result, eventId: eventId)
@@ -574,15 +576,23 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
                 let endDate = Date (timeIntervalSince1970: endDateNumber!.doubleValue / 1000.0)
                                 
                 let predicate = self.eventStore.predicateForEvents(withStart: startDate, end: endDate, calendars: nil)
-                let ekEvent = self.eventStore.events(matching: predicate) as [EKEvent]?
+                let foundEkEvents = self.eventStore.events(matching: predicate) as [EKEvent]?
                 
-                if ekEvent == nil || ekEvent?.count == 0 {
+                if foundEkEvents == nil || foundEkEvents?.count == 0 {
                     self.finishWithEventNotFoundError(result: result, eventId: eventId)
                     return
                 }
                 
+                let ekEvent = foundEkEvents!.first(where: {$0.eventIdentifier == eventId})
+                
                 do {
-                    try self.eventStore.remove(ekEvent!.first!, span: .thisEvent, commit: true)
+                    if (!followingInstances!) {
+                        try self.eventStore.remove(ekEvent!, span: .thisEvent, commit: true)
+                    }
+                    else {
+                        try self.eventStore.remove(ekEvent!, span: .futureEvents, commit: true)
+                    }
+                    
                     result(true)
                 } catch {
                     self.eventStore.reset()

--- a/device_calendar/lib/src/common/calendar_enums.dart
+++ b/device_calendar/lib/src/common/calendar_enums.dart
@@ -12,7 +12,7 @@ enum DayOfWeekGroup {
   None,
   Weekday,
   Weekend,
-  Alldays
+  AllDays
 }
 
 enum MonthOfYear {
@@ -76,7 +76,7 @@ extension DaysOfWeekGroupExtension on DayOfWeekGroup {
         return [DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday];
       case DayOfWeekGroup.Weekend:
         return [DayOfWeek.Saturday, DayOfWeek.Sunday];
-      case DayOfWeekGroup.Alldays:
+      case DayOfWeekGroup.AllDays:
         return [DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Saturday, DayOfWeek.Sunday];
       default:
         return [];

--- a/device_calendar/lib/src/common/calendar_enums.dart
+++ b/device_calendar/lib/src/common/calendar_enums.dart
@@ -12,8 +12,7 @@ enum DayOfWeekGroup {
   None,
   Weekday,
   Weekend,
-  Alldays,
-  Custom
+  Alldays
 }
 
 enum MonthOfYear {

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -131,9 +131,10 @@ class DeviceCalendarPlugin {
     return res;
   }
 
-  /// Deletes an event from a calendar. For a recurring event, this will delete all instances of it
+  /// Deletes an event from a calendar. For a recurring event, this will delete all instances of it.\
+  /// To delete individual instance of a recurring event, please use [deleteEventInstance()]
   ///
-  /// The `calendarId` paramter is the id of the calendar that plugin will try to delete the event from
+  /// The `calendarId` parameter is the id of the calendar that plugin will try to delete the event from\
   /// The `eventId` parameter is the id of the event that plugin will try to delete
   ///
   /// Returns a [Result] indicating if the event has (true) or has not (false) been deleted from the calendar
@@ -149,6 +150,33 @@ class DeviceCalendarPlugin {
     try {
       res.data = await channel.invokeMethod('deleteEvent',
           <String, Object>{'calendarId': calendarId, 'eventId': eventId});
+    } catch (e) {
+      _parsePlatformExceptionAndUpdateResult<bool>(e, res);
+    }
+
+    return res;
+  }
+
+  /// Deletes an instance of a recurring event from a calendar. This should be used for a recurring event only.
+  ///
+  /// The `calendarId` parameter is the id of the calendar that plugin will try to delete the event from\
+  /// The `eventId` parameter is the id of the event that plugin will try to delete\
+  /// The `startDate` parameter is the start date of the instance to delete\
+  /// The `endDate` parameter is the end date of the instance to delete
+  ///
+  /// Returns a [Result] indicating if the instance of the event has (true) or has not (false) been deleted from the calendar
+  Future<Result<bool>> deleteEventInstance(String calendarId, String eventId, int startDate, int endDate) async {
+    final res = Result<bool>();
+
+    if ((calendarId?.isEmpty ?? true) || (eventId?.isEmpty ?? true)) {
+      res.errorMessages.add(
+          '[${ErrorCodes.invalidArguments}] ${ErrorMessages.deleteEventInvalidArgumentsMessage}');
+      return res;
+    }
+
+    try {
+      res.data = await channel.invokeMethod('deleteEventInstance',
+          <String, Object>{'calendarId': calendarId, 'eventId': eventId, 'eventStartDate': startDate, 'eventEndDate': endDate});
     } catch (e) {
       _parsePlatformExceptionAndUpdateResult<bool>(e, res);
     }

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -157,15 +157,17 @@ class DeviceCalendarPlugin {
     return res;
   }
 
-  /// Deletes an instance of a recurring event from a calendar. This should be used for a recurring event only.
+  /// Deletes an instance of a recurring event from a calendar. This should be used for a recurring event only.\
+  /// If `startDate`, `endDate` or `deleteFollowingInstances` is not valid or null, then all instances of the event will be deleted.
   ///
   /// The `calendarId` parameter is the id of the calendar that plugin will try to delete the event from\
   /// The `eventId` parameter is the id of the event that plugin will try to delete\
   /// The `startDate` parameter is the start date of the instance to delete\
-  /// The `endDate` parameter is the end date of the instance to delete
+  /// The `endDate` parameter is the end date of the instance to delete\
+  /// The `deleteFollowingInstances` parameter will also delete the following instances if set to true
   ///
   /// Returns a [Result] indicating if the instance of the event has (true) or has not (false) been deleted from the calendar
-  Future<Result<bool>> deleteEventInstance(String calendarId, String eventId, int startDate, int endDate) async {
+  Future<Result<bool>> deleteEventInstance(String calendarId, String eventId, int startDate, int endDate, bool deleteFollowingInstances) async {
     final res = Result<bool>();
 
     if ((calendarId?.isEmpty ?? true) || (eventId?.isEmpty ?? true)) {
@@ -176,7 +178,13 @@ class DeviceCalendarPlugin {
 
     try {
       res.data = await channel.invokeMethod('deleteEventInstance',
-          <String, Object>{'calendarId': calendarId, 'eventId': eventId, 'eventStartDate': startDate, 'eventEndDate': endDate});
+        <String, Object>{
+          'calendarId': calendarId,
+          'eventId': eventId,
+          'eventStartDate': startDate,
+          'eventEndDate': endDate,
+          'followingInstances': deleteFollowingInstances
+        });
     } catch (e) {
       _parsePlatformExceptionAndUpdateResult<bool>(e, res);
     }


### PR DESCRIPTION
Issue No: #108 

- Event delete instance (and following instances if wanted)
- Added note that deleting instance and the following of an event will take time to be synced
- Properly retrieves the correct calendar
- Removed `Custom` item from `DayOfWeekGroup` enum