### PR TITLE
Remove native ios event modal tool bar

### DIFF
--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -413,7 +413,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                     context,
                                     MaterialPageRoute(
                                         builder: (context) =>
-                                            const EventAttendeePage()));
+                                            EventAttendeePage(eventId: _event?.eventId)));
                                 if (result != null) {
                                   _attendees ??= [];
                                   setState(() {

--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -1009,15 +1009,13 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
                     let flutterViewController = getTopMostViewController()
                     let navigationController = UINavigationController(rootViewController: eventController)
 
-                    navigationController.toolbar.isTranslucent = false
-                    navigationController.toolbar.tintColor = .blue
-                    navigationController.toolbar.backgroundColor = .white
+                    navigationController.setToolbarHidden(true, animated: false)
 
                     flutterViewController.present(navigationController, animated: true, completion: nil)
 
 
                 } else {
-                    result(FlutterError(code: self.genericError, message: self.eventNotFoundErrorMessageFormat, details: nil))
+                    self.finishWithEventNotFoundError(result: result, eventId: eventId)
                 }
             }, result: result)
         }


### PR DESCRIPTION
Fix #568 

I believe that in this scenario where we call the iOS event modal, we don’t need the toolbar and can set it to be hidden. This adjustment should fix the issue of abnormal transparent padding at the bottom of the modal.

In addition, I also fixed a missing eventId parameter in example/../calendar_event.dart. The EventAttendeePage component was not receiving the eventId, which was preventing it from demonstrating the functionality of opening the iOS event modal.

The following screenshot shows the result after the fix: calling ```showiOSEventModal``` in the EventAttendeePage example now displays the bottom edge correctly.
![101731510727_ pic](https://github.com/user-attachments/assets/48f2a700-9193-4f65-99c3-1dee52575909)
