### PR TITLE
Fix recurring event deletion by clearing recurrence fields

### DIFF
--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -760,6 +760,12 @@ class CalendarDelegate(binding: ActivityPluginBinding?, context: Context) :
             val contentResolver: ContentResolver? = _context?.contentResolver
             if (startDate == null && endDate == null && followingInstances == null) { // Delete all instances
                 val eventsUriWithId = ContentUris.withAppendedId(Events.CONTENT_URI, eventIdNumber)
+                val clearRecurrenceValues = ContentValues().apply {
+                    putNull(Events.RRULE)
+                    putNull(Events.EXRULE)
+                    putNull(Events.EXDATE)
+                } // Clear recurrence data to avoid leaving orphaned recurrence info
+                contentResolver?.update(eventsUriWithId, clearRecurrenceValues, null, null)
                 val deleteSucceeded = contentResolver?.delete(eventsUriWithId, null, null) ?: 0
                 finishWithSuccess(deleteSucceeded > 0, pendingChannelResult)
             } else {

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -41,6 +41,8 @@ import org.dmfs.rfc5545.recur.Freq as RruleFreq
 import org.dmfs.rfc5545.recur.RecurrenceRule as Rrule
 import android.provider.CalendarContract.Colors
 import androidx.collection.SparseArrayCompat
+import android.content.ContentProviderResult
+import android.content.ContentProviderOperation
 
 private const val RETRIEVE_CALENDARS_REQUEST_CODE = 0
 private const val RETRIEVE_EVENTS_REQUEST_CODE = RETRIEVE_CALENDARS_REQUEST_CODE + 1
@@ -760,14 +762,32 @@ class CalendarDelegate(binding: ActivityPluginBinding?, context: Context) :
             val contentResolver: ContentResolver? = _context?.contentResolver
             if (startDate == null && endDate == null && followingInstances == null) { // Delete all instances
                 val eventsUriWithId = ContentUris.withAppendedId(Events.CONTENT_URI, eventIdNumber)
+                val ops = ArrayList<ContentProviderOperation>()
                 val clearRecurrenceValues = ContentValues().apply {
                     putNull(Events.RRULE)
                     putNull(Events.EXRULE)
                     putNull(Events.EXDATE)
                 } // Clear recurrence data to avoid leaving orphaned recurrence info
-                contentResolver?.update(eventsUriWithId, clearRecurrenceValues, null, null)
-                val deleteSucceeded = contentResolver?.delete(eventsUriWithId, null, null) ?: 0
-                finishWithSuccess(deleteSucceeded > 0, pendingChannelResult)
+                ops.add(
+                    ContentProviderOperation.newUpdate(eventsUriWithId)
+                        .withValues(clearRecurrenceValues)
+                        .build()
+                )
+                ops.add(
+                    ContentProviderOperation.newDelete(eventsUriWithId)
+                        .build()
+                )
+                try {
+                    // Apply both operations as a single atomic batch
+                    val results = contentResolver?.applyBatch(CalendarContract.AUTHORITY, ops)
+                    // The delete operation is the second one in the batch (index 1).
+                    // A successful delete will have a count of 1.
+                    val deleteSucceeded = results?.get(1)?.count ?: 0 > 0
+                    finishWithSuccess(deleteSucceeded, pendingChannelResult)
+                } catch (e: Exception) {
+                    // Handle potential exceptions from applyBatch, like OperationApplicationException
+                    finishWithError(EC.GENERIC_ERROR, e.message, pendingChannelResult)
+                }
             } else {
                 if (!followingInstances!!) { // Only this instance
                     val exceptionUriWithId =


### PR DESCRIPTION
This pull request addresses an issue where deleting a recurring event on local calendars was corrupting the instance projection, causing unrelated events to disappear from queries. The underlying problem was that deleting the event left orphaned recurrence data (such as RRULE, EXRULE, and EXDATE) in the calendar provider, which interfered with how the Instances table was expanded.

Changes Made:

Clearing Recurrence Fields: Before deleting a recurring event, the code now updates the event to set the recurrence-related fields (RRULE, EXRULE, EXDATE) to null. This prevents leftover recurrence data from affecting the instance projection.

Old behavior:
Deleting the recurring event makes the single event dissapear
https://github.com/user-attachments/assets/cdc164e9-3f3f-420d-87d0-08ab73ec73e5

New behavior:
Deleting the reccuring event has no effect on the single event
https://github.com/user-attachments/assets/d62c6b27-a105-46db-8b2c-33b733f18f56



