### PR TITLE
fix: handle blank RRULE strings to prevent crash when reading events from third-party sync adapters

### DIFF
--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -966,7 +966,11 @@ class CalendarDelegate(binding: ActivityPluginBinding?, context: Context) :
     }
 
     private fun parseRecurrenceRuleString(recurrenceRuleString: String?): RecurrenceRule? {
-        if (recurrenceRuleString == null) {
+        // Treat null and blank strings as "no recurrence rule".
+        // RFC 5545 §3.3.10 requires FREQ to be present in any RECUR value, so a blank
+        // string is invalid. Some third-party sync adapters write an
+        // empty string instead of omitting the RRULE column, so both cases must be handled.
+        if (recurrenceRuleString.isNullOrBlank()) {
             return null
         }
         val rfcRecurrenceRule = Rrule(recurrenceRuleString)


### PR DESCRIPTION
## Problem

When retrieving events from calendars synced by certain third-party apps
(e.g. TimeTree), `parseRecurrenceRuleString` throws an
`InvalidRecurrenceRuleException` and crashes the event fetch.

The root cause is that some sync adapters write an **empty string** (`""`)
into the `CalendarContract.Events.RRULE` column instead of leaving it
`null` when an event has no recurrence rule.

The previous `null` check did not catch this case, causing `Rrule("")` to
be called, which throws because `FREQ` is missing.

## Root Cause

RFC 5545 §3.3.10 states:

> "The FREQ rule part is REQUIRED, but MUST NOT occur more than once."

An empty string is therefore an invalid RECUR value. The correct behavior
for a non-recurring event is to omit the `RRULE` property entirely (i.e.,
store `null`). Google Calendar's sync adapter does this correctly; TimeTree
does not.

## Fix

Replace the `null` check with `isNullOrBlank()` so that both `null` and
blank strings are treated as "no recurrence rule".

```kotlin
// Before
if (recurrenceRuleString == null) {

// After
if (recurrenceRuleString.isNullOrBlank()) {