### PR TITLE
fix(ios): use singleton EKEventStore to fix permission sync issues

### DIFF
--- a/ios/Classes/EventStoreManager.swift
+++ b/ios/Classes/EventStoreManager.swift
@@ -1,0 +1,11 @@
+import EventKit
+
+class EventStoreManager {
+    static let shared = EventStoreManager()
+    
+    let eventStore: EKEventStore
+    
+    private init() {
+        eventStore = EKEventStore()
+    }
+}

--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -102,7 +102,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
     let calendarNotFoundErrorMessageFormat = "The calendar with the ID %@ could not be found"
     let calendarReadOnlyErrorMessageFormat = "Calendar with ID %@ is read-only"
     let eventNotFoundErrorMessageFormat = "The event with the ID %@ could not be found"
-    let eventStore = EKEventStore()
+    let eventStore = EventStoreManager.shared.eventStore
     let requestPermissionsMethod = "requestPermissions"
     let hasPermissionsMethod = "hasPermissions"
     let retrieveCalendarsMethod = "retrieveCalendars"


### PR DESCRIPTION
- Create EventStoreManager singleton for shared EKEventStore instance
- Replace direct EKEventStore instantiation with singleton reference
- Fixes iOS 17/18 permission synchronization issues
- Ensures consistent EventStore state across the app